### PR TITLE
(0x10 다이나믹 프로그래밍) Update 14501_1.cpp

### DIFF
--- a/0x10/solutions/14501_1.cpp
+++ b/0x10/solutions/14501_1.cpp
@@ -1,0 +1,30 @@
+// Authored by : sukam09
+// Co-authored by : -
+// http://boj.kr/6632759b10194d6db06cc930356d48af
+#include <bits/stdc++.h>
+using namespace std;
+
+int t[1500005];
+int p[1500005];
+int d[1500005]; // i번째 일에 상담을 시작했을 때 얻을 수 있는 최대 수익
+
+int main(void){
+  ios::sync_with_stdio(0);
+  cin.tie(0);
+  
+  int n;
+  cin >> n;
+  
+  for (int i = 1; i <= n; i++) cin >> t[i] >> p[i];
+  
+  for (int i = n; i >= 1; i--) {
+    // i번째 일에 상담을 할 수 있을 경우
+    if (i + t[i] <= n + 1) {
+      // i번째 일에 상담을 했을 때와 상담을 하지 않았을 때 중 최대 수익을 취함
+      d[i] = max(d[i + t[i]] + p[i], d[i + 1]);
+    }
+    else d[i] = d[i + 1];
+  }
+
+  cout << *max_element(d, d + n + 1);
+}


### PR DESCRIPTION
0x10 다이나믹 프로그래밍 14501번 퇴사 문제입니다.
개인적으로 이 문제는 뒤에서부터 dp table을 채우는 방식이 훨씬 직관적이고 이해하기 쉽다고 생각해서 풀이를 추가해봅니다.

+추가로 이 문제는 N의 제한이 너무 작아 DP가 아니라 조합이나 백트래킹 등으로도 AC를 받을 수 있으므로 15486번 퇴사 2 문제로 대체하는 것이 낫지 않나 조심스레 건의해봅니다.