### PR TITLE
fix: 0x0D 14500_2.cpp

### DIFF
--- a/0x0D/solutions/14500_2.cpp
+++ b/0x0D/solutions/14500_2.cpp
@@ -1,7 +1,6 @@
 // Authored by : scsc3204
 // Co-authored by : -
 // http://boj.kr/d1845ccb4a6345f597884753edba728e
-
 #include <bits/stdc++.h>
 using namespace std;
 
@@ -63,5 +62,5 @@ int main(void) {
 길이가 4인 루트를 찾는 백트래킹으로 얻을 수 있다.
 ㅗㅜㅓㅏ는 cnt == 2에서 3번째 정사각형을 뽑은 뒤
 현위치인 (cx, cy)를 인자로 다시 보내 찾을 수 있다.
-해당 코드는 31-32번째 줄과 같이 구현된다.
+해당 코드는 34-35번째 줄과 같이 구현된다.
 */


### PR DESCRIPTION
"0x0D 시뮬레이션" 단원 "14500번 - 테트로미노" 별해 2번
수정 후 PR을 올립니다. 수정 내용은 아래와 같습니다.

- 4번째 줄의 공백 삭제
- 주석 수정: 31-32번째 줄과 같이 구현된다 -> 34-35번째 줄과 같이 구현된다.

항상 감사합니다.

문제 링크: https://www.acmicpc.net/problem/14500