### PR TITLE
문제집 링크 복원

### DIFF
--- a/workbook.md
+++ b/workbook.md
@@ -27,38 +27,38 @@
 | :--: | :--: | :--: |
 | 0x00 | 오리엔테이션 (문제집 X) | |
 | 0x01 | 기초 코드 작성 요령 I (문제집 X) | |
-| 0x02 | [기초 코드 작성 요령 II](workbook/0x02.md) | ![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0) |
-| 0x03 | [배열](workbook/0x03.md) | ![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0) |
-| 0x04 | [연결 리스트](workbook/0x04.md) | ![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0) |
-| 0x05 | [스택](workbook/0x05.md) | ![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0) |
-| 0x06 | [큐](workbook/0x06.md) | ![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0) |
-| 0x07 | [덱](workbook/0x07.md) | ![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0) |
-| 0x08 | [스택의 활용(수식의 괄호 쌍)](workbook/0x08.md) | ![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0) |
-| 0x09 | [BFS](workbook/0x09.md) | ![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0) |
+| 0x02 | [기초 코드 작성 요령 II](workbook/0x02.md) | ![100%](https://progress-bar.xyz/27/?scale=27&title=progress&width=500&color=babaca&suffix=/27) |
+| 0x03 | [배열](workbook/0x03.md) | ![100%](https://progress-bar.xyz/8/?scale=8&title=progress&width=500&color=babaca&suffix=/8) |
+| 0x04 | [연결 리스트](workbook/0x04.md) | ![100%](https://progress-bar.xyz/3/?scale=3&title=progress&width=500&color=babaca&suffix=/3) |
+| 0x05 | [스택](workbook/0x05.md) | ![100%](https://progress-bar.xyz/8/?scale=8&title=progress&width=500&color=babaca&suffix=/8) |
+| 0x06 | [큐](workbook/0x06.md) | ![100%](https://progress-bar.xyz/3/?scale=3&title=progress&width=500&color=babaca&suffix=/3) |
+| 0x07 | [덱](workbook/0x07.md) | ![100%](https://progress-bar.xyz/4/?scale=4&title=progress&width=500&color=babaca&suffix=/4) |
+| 0x08 | [스택의 활용(수식의 괄호 쌍)](workbook/0x08.md) | ![100%](https://progress-bar.xyz/5/?scale=5&title=progress&width=500&color=babaca&suffix=/5) |
+| 0x09 | [BFS](workbook/0x09.md) | ![100%](https://progress-bar.xyz/30/?scale=30&title=progress&width=500&color=babaca&suffix=/30) |
 | 0x0A | DFS (문제집 X) | |
-| 0x0B | [재귀](workbook/0x0B.md) | ![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0) |
-| 0x0C | [백트래킹](workbook/0x0C.md) | ![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0) |
-| 0x0D | [시뮬레이션](workbook/0x0D.md) | ![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0) |
-| 0x0E | [정렬 I](workbook/0x0E.md) | ![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0) |
-| 0x0F | [정렬 II](workbook/0x0F.md) | ![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0) |
-| 0x10 | [다이나믹 프로그래밍](workbook/0x10.md) | ![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0) |
-| 0x11 | [그리디](workbook/0x11.md) | ![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0) |
-| 0x12 | [수학](workbook/0x12.md) | ![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0) |
-| 0x13 | [이분탐색](workbook/0x13.md) | ![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0) |
-| 0x14 | [투 포인터](workbook/0x14.md) | ![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0) |
-| 0x15 | [해시](workbook/0x15.md) | ![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0) |
-| 0x16 | [이진 검색 트리](workbook/0x16.md) | ![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0) |
-| 0x17 | [우선순위 큐](workbook/0x17.md) | ![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0) |
-| 0x18 | [그래프](workbook/0x18.md) | ![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0) |
-| 0x19 | [트리](workbook/0x19.md) | ![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0) |
-| 0x1A | [위상 정렬](workbook/0x1A.md) | ![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0) |
-| 0x1B | [최소 신장 트리](workbook/0x1B.md) | ![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0) |
-| 0x1C | [플로이드 알고리즘](workbook/0x1C.md) | ![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0) |
-| 0x1D | [다익스트라 알고리즘](workbook/0x1D.md) | ![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0) |
-| 0x1E | [KMP](workbook/0x1E.md) | ![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0) |
-| 0x1F | [트라이](workbook/0x1F.md) | ![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0) |
-| Appendix A | [문자열 기초](workbook/Appendix%20A.md) | ![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0) |
+| 0x0B | [재귀](workbook/0x0B.md) | ![100%](https://progress-bar.xyz/10/?scale=10&title=progress&width=500&color=babaca&suffix=/10) |
+| 0x0C | [백트래킹](workbook/0x0C.md) | ![100%](https://progress-bar.xyz/20/?scale=20&title=progress&width=500&color=babaca&suffix=/20) |
+| 0x0D | [시뮬레이션](workbook/0x0D.md) | ![100%](https://progress-bar.xyz/42/?scale=61&title=progress&width=500&color=babaca&suffix=/61) |
+| 0x0E | [정렬 I](workbook/0x0E.md) | ![100%](https://progress-bar.xyz/8/?scale=8&title=progress&width=500&color=babaca&suffix=/8) |
+| 0x0F | [정렬 II](workbook/0x0F.md) | ![100%](https://progress-bar.xyz/9/?scale=9&title=progress&width=500&color=babaca&suffix=/9) |
+| 0x10 | [다이나믹 프로그래밍](workbook/0x10.md) | ![100%](https://progress-bar.xyz/31/?scale=31&title=progress&width=500&color=babaca&suffix=/31) |
+| 0x11 | [그리디](workbook/0x11.md) | ![100%](https://progress-bar.xyz/17/?scale=17&title=progress&width=500&color=babaca&suffix=/17) |
+| 0x12 | [수학](workbook/0x12.md) | ![100%](https://progress-bar.xyz/38/?scale=39&title=progress&width=500&color=babaca&suffix=/39) |
+| 0x13 | [이분탐색](workbook/0x13.md) | ![100%](https://progress-bar.xyz/20/?scale=21&title=progress&width=500&color=babaca&suffix=/21) |
+| 0x14 | [투 포인터](workbook/0x14.md) | ![100%](https://progress-bar.xyz/11/?scale=11&title=progress&width=500&color=babaca&suffix=/11) |
+| 0x15 | [해시](workbook/0x15.md) | ![100%](https://progress-bar.xyz/9/?scale=9&title=progress&width=500&color=babaca&suffix=/9) |
+| 0x16 | [이진 검색 트리](workbook/0x16.md) | ![100%](https://progress-bar.xyz/7/?scale=7&title=progress&width=500&color=babaca&suffix=/7) |
+| 0x17 | [우선순위 큐](workbook/0x17.md) | ![100%](https://progress-bar.xyz/8/?scale=8&title=progress&width=500&color=babaca&suffix=/8) |
+| 0x18 | [그래프](workbook/0x18.md) | ![100%](https://progress-bar.xyz/13/?scale=13&title=progress&width=500&color=babaca&suffix=/13) |
+| 0x19 | [트리](workbook/0x19.md) | ![100%](https://progress-bar.xyz/13/?scale=13&title=progress&width=500&color=babaca&suffix=/13) |
+| 0x1A | [위상 정렬](workbook/0x1A.md) | ![100%](https://progress-bar.xyz/7/?scale=7&title=progress&width=500&color=babaca&suffix=/7) |
+| 0x1B | [최소 신장 트리](workbook/0x1B.md) | ![100%](https://progress-bar.xyz/9/?scale=9&title=progress&width=500&color=babaca&suffix=/9) |
+| 0x1C | [플로이드 알고리즘](workbook/0x1C.md) | ![100%](https://progress-bar.xyz/14/?scale=15&title=progress&width=500&color=babaca&suffix=/15) |
+| 0x1D | [다익스트라 알고리즘](workbook/0x1D.md) | ![100%](https://progress-bar.xyz/12/?scale=14&title=progress&width=500&color=babaca&suffix=/14) |
+| 0x1E | [KMP](workbook/0x1E.md) | ![100%](https://progress-bar.xyz/8/?scale=8&title=progress&width=500&color=babaca&suffix=/8) |
+| 0x1F | [트라이](workbook/0x1F.md) | ![100%](https://progress-bar.xyz/10/?scale=10&title=progress&width=500&color=babaca&suffix=/10) |
+| Appendix A | [문자열 기초](workbook/Appendix%20A.md) | ![100%](https://progress-bar.xyz/13/?scale=16&title=progress&width=500&color=babaca&suffix=/16) |
 | Appendix B | 동적 배열 (문제집 X) | |
-| Appendix C | [비트마스킹](workbook/Appendix%20C.md) | ![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0) |
-| Appendix D | [Union-Find](workbook/Appendix%20D.md) | ![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0) |
-| Appendix E | [다이나믹 프로그래밍 심화](workbook/Appendix%20E.md) | ![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0) |
+| Appendix C | [비트마스킹](workbook/Appendix%20C.md) | ![100%](https://progress-bar.xyz/2/?scale=7&title=progress&width=500&color=babaca&suffix=/7) |
+| Appendix D | [Union-Find](workbook/Appendix%20D.md) | ![100%](https://progress-bar.xyz/2/?scale=9&title=progress&width=500&color=babaca&suffix=/9) |
+| Appendix E | [다이나믹 프로그래밍 심화](workbook/Appendix%20E.md) | ![100%](https://progress-bar.xyz/17/?scale=25&title=progress&width=500&color=babaca&suffix=/25) |

--- a/workbook/0x02.md
+++ b/workbook/0x02.md
@@ -1,8 +1,35 @@
 # 기초 코드 작성 요령 II
 
-![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0)
+![100%](https://progress-bar.xyz/27/?scale=27&title=progress&width=500&color=babaca&suffix=/27)
 
 [문제집 링크](https://www.acmicpc.net/workbook/view/7306)
 
 | 문제 분류 | 문제 | 문제 제목 | 정답 코드 |
 | :--: | :--: | :--: | :--: |
+| 연습 문제 | 10871 | [X보다 작은 수](https://www.acmicpc.net/problem/10871) | [정답 코드](../0x02/solutions/10871.cpp) |
+| 기본 문제✔ | 1000 | [A+B](https://www.acmicpc.net/problem/1000) | [정답 코드](../0x02/solutions/1000.cpp) |
+| 기본 문제✔ | 2557 | [Hello World](https://www.acmicpc.net/problem/2557) | [정답 코드](../0x02/solutions/2557.cpp) |
+| 기본 문제✔ | 10171 | [고양이](https://www.acmicpc.net/problem/10171) | [정답 코드](../0x02/solutions/10171.cpp) |
+| 기본 문제✔ | 10869 | [사칙연산](https://www.acmicpc.net/problem/10869) | [정답 코드](../0x02/solutions/10869.cpp) |
+| 기본 문제✔ | 9498 | [시험 성적](https://www.acmicpc.net/problem/9498) | [정답 코드](../0x02/solutions/9498.cpp) |
+| 기본 문제✔ | 2752 | [세수정렬](https://www.acmicpc.net/problem/2752) | [정답 코드](../0x02/solutions/2752.cpp), [별해 1](../0x02/solutions/2752_1.cpp) |
+| 기본 문제✔ | 2753 | [윤년](https://www.acmicpc.net/problem/2753) | [정답 코드](../0x02/solutions/2753.cpp) |
+| 기본 문제✔ | 2480 | [주사위 세개](https://www.acmicpc.net/problem/2480) | [정답 코드](../0x02/solutions/2480.cpp), [별해 1](../0x02/solutions/2480_1.cpp) |
+| 기본 문제✔ | 2490 | [윷놀이](https://www.acmicpc.net/problem/2490) | [정답 코드](../0x02/solutions/2490.cpp) |
+| 기본 문제✔ | 2576 | [홀수](https://www.acmicpc.net/problem/2576) | [정답 코드](../0x02/solutions/2576.cpp) |
+| 기본 문제✔ | 2587 | [대표값2](https://www.acmicpc.net/problem/2587) | [정답 코드](../0x02/solutions/2587.cpp) |
+| 기본 문제✔ | 2309 | [일곱 난쟁이](https://www.acmicpc.net/problem/2309) | [정답 코드](../0x02/solutions/2309.cpp) |
+| 기본 문제✔ | 10093 | [숫자](https://www.acmicpc.net/problem/10093) | [정답 코드](../0x02/solutions/10093.cpp) |
+| 기본 문제✔ | 1267 | [핸드폰 요금](https://www.acmicpc.net/problem/1267) | [정답 코드](../0x02/solutions/1267.cpp) |
+| 기본 문제✔ | 10804 | [카드 역배치](https://www.acmicpc.net/problem/10804) | [정답 코드](../0x02/solutions/10804.cpp), [별해 1](../0x02/solutions/10804_1.cpp) |
+| 기본 문제✔ | 15552 | [빠른 A+B](https://www.acmicpc.net/problem/15552) | [정답 코드](../0x02/solutions/15552.cpp) |
+| 기본 문제✔ | 2438 | [별 찍기 - 1](https://www.acmicpc.net/problem/2438) | [정답 코드](../0x02/solutions/2438.cpp) |
+| 기본 문제✔ | 2439 | [별 찍기 - 2](https://www.acmicpc.net/problem/2439) | [정답 코드](../0x02/solutions/2439.cpp) |
+| 기본 문제✔ | 2440 | [별 찍기 - 3](https://www.acmicpc.net/problem/2440) | [정답 코드](../0x02/solutions/2440.cpp) |
+| 기본 문제✔ | 2441 | [별 찍기 - 4](https://www.acmicpc.net/problem/2441) | [정답 코드](../0x02/solutions/2441.cpp) |
+| 기본 문제✔ | 2442 | [별 찍기 - 5](https://www.acmicpc.net/problem/2442) | [정답 코드](../0x02/solutions/2442.cpp) |
+| 기본 문제✔ | 2443 | [별 찍기 - 6](https://www.acmicpc.net/problem/2443) | [정답 코드](../0x02/solutions/2443.cpp) |
+| 기본 문제✔ | 2444 | [별 찍기 - 7](https://www.acmicpc.net/problem/2444) | [정답 코드](../0x02/solutions/2444.cpp) |
+| 기본 문제✔ | 2445 | [별 찍기 - 8](https://www.acmicpc.net/problem/2445) | [정답 코드](../0x02/solutions/2445.cpp) |
+| 기본 문제✔ | 2446 | [별 찍기 - 9](https://www.acmicpc.net/problem/2446) | [정답 코드](../0x02/solutions/2446.cpp) |
+| 기본 문제✔ | 2562 | [최댓값](https://www.acmicpc.net/problem/2562) | [정답 코드](../0x02/solutions/2562.cpp), [별해 1](../0x02/solutions/2562_1.cpp) |

--- a/workbook/0x03.md
+++ b/workbook/0x03.md
@@ -1,8 +1,16 @@
 # 배열
 
-![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0)
+![100%](https://progress-bar.xyz/8/?scale=8&title=progress&width=500&color=babaca&suffix=/8)
 
 [문제집 링크](https://www.acmicpc.net/workbook/view/7307)
 
 | 문제 분류 | 문제 | 문제 제목 | 정답 코드 |
 | :--: | :--: | :--: | :--: |
+| 연습 문제 | 10808 | [알파벳 개수](https://www.acmicpc.net/problem/10808) | [정답 코드](../0x03/solutions/10808.cpp) |
+| 기본 문제✔ | 2577 | [숫자의 개수](https://www.acmicpc.net/problem/2577) | [정답 코드](../0x03/solutions/2577.cpp) |
+| 기본 문제✔ | 1475 | [방 번호](https://www.acmicpc.net/problem/1475) | [정답 코드](../0x03/solutions/1475.cpp) |
+| 기본 문제✔ | 3273 | [두 수의 합](https://www.acmicpc.net/problem/3273) | [정답 코드](../0x03/solutions/3273.cpp), [별해 1](../0x03/solutions/3273_1.cpp) |
+| 기본 문제 | 10807 | [개수 세기](https://www.acmicpc.net/problem/10807) | [정답 코드](../0x03/solutions/10807.cpp) |
+| 기본 문제 | 13300 | [방 배정](https://www.acmicpc.net/problem/13300) | [정답 코드](../0x03/solutions/13300.cpp) |
+| 기본 문제 | 11328 | [Strfry](https://www.acmicpc.net/problem/11328) | [정답 코드](../0x03/solutions/11328.cpp) |
+| 기본 문제 | 1919 | [애너그램 만들기](https://www.acmicpc.net/problem/1919) | [정답 코드](../0x03/solutions/1919.cpp) |

--- a/workbook/0x04.md
+++ b/workbook/0x04.md
@@ -1,8 +1,11 @@
 # 연결 리스트
 
-![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0)
+![100%](https://progress-bar.xyz/3/?scale=3&title=progress&width=500&color=babaca&suffix=/3)
 
 [문제집 링크](https://www.acmicpc.net/workbook/view/7308)
 
 | 문제 분류 | 문제 | 문제 제목 | 정답 코드 |
 | :--: | :--: | :--: | :--: |
+| 연습 문제 | 1406 | [에디터](https://www.acmicpc.net/problem/1406) | [정답 코드](../0x04/solutions/1406.cpp) |
+| 기본 문제✔ | 5397 | [키로거](https://www.acmicpc.net/problem/5397) | [정답 코드](../0x04/solutions/5397.cpp) |
+| 기본 문제✔ | 1158 | [요세푸스 문제](https://www.acmicpc.net/problem/1158) | [정답 코드](../0x04/solutions/1158.cpp), [별해 1](../0x04/solutions/1158_1.cpp), [별해 2](../0x04/solutions/1158_2.cpp) |

--- a/workbook/0x05.md
+++ b/workbook/0x05.md
@@ -1,8 +1,16 @@
 # 스택
 
-![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0)
+![100%](https://progress-bar.xyz/8/?scale=8&title=progress&width=500&color=babaca&suffix=/8)
 
 [문제집 링크](https://www.acmicpc.net/workbook/view/7309)
 
 | 문제 분류 | 문제 | 문제 제목 | 정답 코드 |
 | :--: | :--: | :--: | :--: |
+| 연습 문제 | 10828 | [스택](https://www.acmicpc.net/problem/10828) | [정답 코드](../0x05/solutions/10828.cpp) |
+| 기본 문제✔ | 10773 | [제로](https://www.acmicpc.net/problem/10773) | [정답 코드](../0x05/solutions/10773.cpp) |
+| 응용 문제✔ | 1874 | [스택 수열](https://www.acmicpc.net/problem/1874) | [정답 코드](../0x05/solutions/1874.cpp) |
+| 응용 문제✔ | 2493 | [탑](https://www.acmicpc.net/problem/2493) | [정답 코드](../0x05/solutions/2493.cpp) |
+| 응용 문제 | 6198 | [옥상 정원 꾸미기](https://www.acmicpc.net/problem/6198) | [정답 코드](../0x05/solutions/6198.cpp) |
+| 응용 문제 | 17298 | [오큰수](https://www.acmicpc.net/problem/17298) | [정답 코드](../0x05/solutions/17298.cpp) |
+| 응용 문제 | 3015 | [오아시스 재결합](https://www.acmicpc.net/problem/3015) | [정답 코드](../0x05/solutions/3015.cpp) |
+| 응용 문제 | 6549 | [히스토그램에서 가장 큰 직사각형](https://www.acmicpc.net/problem/6549) | [정답 코드](../0x05/solutions/6549.cpp) |

--- a/workbook/0x06.md
+++ b/workbook/0x06.md
@@ -1,8 +1,11 @@
 # 큐
 
-![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0)
+![100%](https://progress-bar.xyz/3/?scale=3&title=progress&width=500&color=babaca&suffix=/3)
 
 [문제집 링크](https://www.acmicpc.net/workbook/view/7310)
 
 | 문제 분류 | 문제 | 문제 제목 | 정답 코드 |
 | :--: | :--: | :--: | :--: |
+| 연습 문제 | 10845 | [큐](https://www.acmicpc.net/problem/10845) | [정답 코드](../0x06/solutions/10845.cpp) |
+| 기본 문제✔ | 18258 | [큐 2](https://www.acmicpc.net/problem/18258) | [정답 코드](../0x06/solutions/18258.cpp), [별해 1](../0x06/solutions/18258_1.cpp) |
+| 기본 문제✔ | 2164 | [카드2](https://www.acmicpc.net/problem/2164) | [정답 코드](../0x06/solutions/2164.cpp) |

--- a/workbook/0x07.md
+++ b/workbook/0x07.md
@@ -1,8 +1,12 @@
 # 덱
 
-![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0)
+![100%](https://progress-bar.xyz/4/?scale=4&title=progress&width=500&color=babaca&suffix=/4)
 
 [문제집 링크](https://www.acmicpc.net/workbook/view/7311)
 
 | 문제 분류 | 문제 | 문제 제목 | 정답 코드 |
 | :--: | :--: | :--: | :--: |
+| 연습 문제 | 10866 | [덱](https://www.acmicpc.net/problem/10866) | [정답 코드](../0x07/solutions/10866.cpp) |
+| 기본 문제✔ | 1021 | [회전하는 큐](https://www.acmicpc.net/problem/1021) | [정답 코드](../0x07/solutions/1021.cpp) |
+| 응용 문제✔ | 5430 | [AC](https://www.acmicpc.net/problem/5430) | [정답 코드](../0x07/solutions/5430.cpp), [별해 1](../0x07/solutions/5430_1.cpp) |
+| 응용 문제 | 11003 | [최솟값 찾기](https://www.acmicpc.net/problem/11003) | [정답 코드](../0x07/solutions/11003.cpp), [별해 1](../0x07/solutions/11003_1.cpp) |

--- a/workbook/0x08.md
+++ b/workbook/0x08.md
@@ -1,8 +1,13 @@
 # 스택의 활용(수식의 괄호 쌍)
 
-![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0)
+![100%](https://progress-bar.xyz/5/?scale=5&title=progress&width=500&color=babaca&suffix=/5)
 
 [문제집 링크](https://www.acmicpc.net/workbook/view/7312)
 
 | 문제 분류 | 문제 | 문제 제목 | 정답 코드 |
 | :--: | :--: | :--: | :--: |
+| 연습 문제 | 4949 | [균형잡힌 세상](https://www.acmicpc.net/problem/4949) | [정답 코드](../0x08/solutions/4949.cpp) |
+| 기본 문제✔ | 3986 | [좋은 단어](https://www.acmicpc.net/problem/3986) | [정답 코드](../0x08/solutions/3986.cpp) |
+| 기본 문제 | 9012 | [괄호](https://www.acmicpc.net/problem/9012) | [정답 코드](../0x08/solutions/9012.cpp) |
+| 응용 문제✔ | 10799 | [쇠막대기](https://www.acmicpc.net/problem/10799) | [정답 코드](../0x08/solutions/10799.cpp) |
+| 응용 문제✔ | 2504 | [괄호의 값](https://www.acmicpc.net/problem/2504) | [정답 코드](../0x08/solutions/2504.cpp) |

--- a/workbook/0x09.md
+++ b/workbook/0x09.md
@@ -1,8 +1,38 @@
 # BFS
 
-![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0)
+![100%](https://progress-bar.xyz/30/?scale=30&title=progress&width=500&color=babaca&suffix=/30)
 
 [문제집 링크](https://www.acmicpc.net/workbook/view/7313)
 
 | 문제 분류 | 문제 | 문제 제목 | 정답 코드 |
 | :--: | :--: | :--: | :--: |
+| 연습 문제 | 1926 | [그림](https://www.acmicpc.net/problem/1926) | [정답 코드](../0x09/solutions/1926.cpp) |
+| 연습 문제 | 2178 | [미로 탐색](https://www.acmicpc.net/problem/2178) | [정답 코드](../0x09/solutions/2178.cpp) |
+| 연습 문제 | 7576 | [토마토](https://www.acmicpc.net/problem/7576) | [정답 코드](../0x09/solutions/7576.cpp) |
+| 연습 문제 | 4179 | [불!](https://www.acmicpc.net/problem/4179) | [정답 코드](../0x09/solutions/4179.cpp) |
+| 연습 문제 | 1697 | [숨바꼭질](https://www.acmicpc.net/problem/1697) | [정답 코드](../0x09/solutions/1697.cpp) |
+| 기본 문제✔ | 1012 | [유기농 배추](https://www.acmicpc.net/problem/1012) | [정답 코드](../0x09/solutions/1012.cpp) |
+| 기본 문제✔ | 10026 | [적록색약](https://www.acmicpc.net/problem/10026) | [정답 코드](../0x09/solutions/10026.cpp) |
+| 기본 문제✔ | 7569 | [토마토](https://www.acmicpc.net/problem/7569) | [정답 코드](../0x09/solutions/7569.cpp) |
+| 기본 문제✔ | 7562 | [나이트의 이동](https://www.acmicpc.net/problem/7562) | [정답 코드](../0x09/solutions/7562.cpp) |
+| 기본 문제✔ | 5427 | [불](https://www.acmicpc.net/problem/5427) | [정답 코드](../0x09/solutions/5427.cpp) |
+| 기본 문제 | 2583 | [영역 구하기](https://www.acmicpc.net/problem/2583) | [정답 코드](../0x09/solutions/2583.cpp) |
+| 기본 문제 | 2667 | [단지번호붙이기](https://www.acmicpc.net/problem/2667) | [정답 코드](../0x09/solutions/2667.cpp) |
+| 기본 문제 | 5014 | [스타트링크](https://www.acmicpc.net/problem/5014) | [정답 코드](../0x09/solutions/5014.cpp) |
+| 기본 문제 | 2468 | [안전 영역](https://www.acmicpc.net/problem/2468) | [정답 코드](../0x09/solutions/2468.cpp) |
+| 기본 문제 | 6593 | [상범 빌딩](https://www.acmicpc.net/problem/6593) | [정답 코드](../0x09/solutions/6593.cpp) |
+| 응용 문제✔ | 2206 | [벽 부수고 이동하기](https://www.acmicpc.net/problem/2206) | [정답 코드](../0x09/solutions/2206.cpp) |
+| 응용 문제✔ | 9466 | [텀 프로젝트](https://www.acmicpc.net/problem/9466) | [정답 코드](../0x09/solutions/9466.cpp) |
+| 응용 문제✔ | 2573 | [빙산](https://www.acmicpc.net/problem/2573) | [정답 코드](../0x09/solutions/2573.cpp) |
+| 응용 문제✔ | 2146 | [다리 만들기](https://www.acmicpc.net/problem/2146) | [정답 코드](../0x09/solutions/2146.cpp), [별해 1](../0x09/solutions/2146_1.cpp) |
+| 응용 문제✔ | 13549 | [숨바꼭질 3](https://www.acmicpc.net/problem/13549) | [정답 코드](../0x09/solutions/13549.cpp), [별해 1](../0x09/solutions/13549_1.cpp) |
+| 응용 문제✔ | 1600 | [말이 되고픈 원숭이](https://www.acmicpc.net/problem/1600) | [정답 코드](../0x09/solutions/1600.cpp) |
+| 응용 문제 | 13913 | [숨바꼭질 4](https://www.acmicpc.net/problem/13913) | [정답 코드](../0x09/solutions/13913.cpp) |
+| 응용 문제 | 14442 | [벽 부수고 이동하기 2](https://www.acmicpc.net/problem/14442) | [정답 코드](../0x09/solutions/14442.cpp) |
+| 응용 문제 | 16933 | [벽 부수고 이동하기 3](https://www.acmicpc.net/problem/16933) | [정답 코드](../0x09/solutions/16933.cpp) |
+| 응용 문제 | 16920 | [확장 게임](https://www.acmicpc.net/problem/16920) | [정답 코드](../0x09/solutions/16920.cpp) |
+| 응용 문제 | 11967 | [불켜기](https://www.acmicpc.net/problem/11967) | [정답 코드](../0x09/solutions/11967.cpp) |
+| 응용 문제 | 17071 | [숨바꼭질 5](https://www.acmicpc.net/problem/17071) | [정답 코드](../0x09/solutions/17071.cpp) |
+| 응용 문제 | 9328 | [열쇠](https://www.acmicpc.net/problem/9328) | [정답 코드](../0x09/solutions/9328.cpp) |
+| 응용 문제 | 3197 | [백조의 호수](https://www.acmicpc.net/problem/3197) | [정답 코드](../0x09/solutions/3197.cpp) |
+| 응용 문제 | 20304 | [비밀번호 제작](https://www.acmicpc.net/problem/20304) | [정답 코드](../0x09/solutions/20304.cpp) |

--- a/workbook/0x0B.md
+++ b/workbook/0x0B.md
@@ -1,8 +1,18 @@
 # 재귀
 
-![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0)
+![100%](https://progress-bar.xyz/10/?scale=10&title=progress&width=500&color=babaca&suffix=/10)
 
 [문제집 링크](https://www.acmicpc.net/workbook/view/7314)
 
 | 문제 분류 | 문제 | 문제 제목 | 정답 코드 |
 | :--: | :--: | :--: | :--: |
+| 연습 문제 | 1629 | [곱셈](https://www.acmicpc.net/problem/1629) | [정답 코드](../0x0B/solutions/1629.cpp) |
+| 연습 문제 | 11729 | [하노이 탑 이동 순서](https://www.acmicpc.net/problem/11729) | [정답 코드](../0x0B/solutions/11729.cpp) |
+| 연습 문제 | 1074 | [Z](https://www.acmicpc.net/problem/1074) | [정답 코드](../0x0B/solutions/1074.cpp) |
+| 기본 문제✔ | 17478 | [재귀함수가 뭔가요?](https://www.acmicpc.net/problem/17478) | [정답 코드](../0x0B/solutions/17478.cpp) |
+| 기본 문제✔ | 1780 | [종이의 개수](https://www.acmicpc.net/problem/1780) | [정답 코드](../0x0B/solutions/1780.cpp) |
+| 기본 문제✔ | 2630 | [색종이 만들기](https://www.acmicpc.net/problem/2630) | [정답 코드](../0x0B/solutions/2630.cpp) |
+| 기본 문제✔ | 1992 | [쿼드트리](https://www.acmicpc.net/problem/1992) | [정답 코드](../0x0B/solutions/1992.cpp) |
+| 응용 문제✔ | 2447 | [별 찍기 - 10](https://www.acmicpc.net/problem/2447) | [정답 코드](../0x0B/solutions/2447.cpp), [별해 1](../0x0B/solutions/2447_1.cpp) |
+| 응용 문제✔ | 2448 | [별 찍기 - 11](https://www.acmicpc.net/problem/2448) | [정답 코드](../0x0B/solutions/2448.cpp), [별해 1](../0x0B/solutions/2448_1.cpp) |
+| 응용 문제 | 14956 | [Philosopher’s Walk](https://www.acmicpc.net/problem/14956) | [정답 코드](../0x0B/solutions/14956.cpp) |

--- a/workbook/0x0C.md
+++ b/workbook/0x0C.md
@@ -1,8 +1,28 @@
 # 백트래킹
 
-![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0)
+![100%](https://progress-bar.xyz/20/?scale=20&title=progress&width=500&color=babaca&suffix=/20)
 
 [문제집 링크](https://www.acmicpc.net/workbook/view/7315)
 
 | 문제 분류 | 문제 | 문제 제목 | 정답 코드 |
 | :--: | :--: | :--: | :--: |
+| 연습 문제 | 15649 | [N과 M (1)](https://www.acmicpc.net/problem/15649) | [정답 코드](../0x0C/solutions/15649.cpp) |
+| 연습 문제 | 9663 | [N-Queen](https://www.acmicpc.net/problem/9663) | [정답 코드](../0x0C/solutions/9663.cpp) |
+| 연습 문제 | 1182 | [부분수열의 합](https://www.acmicpc.net/problem/1182) | [정답 코드](../0x0C/solutions/1182.cpp) |
+| 기본 문제✔ | 15650 | [N과 M (2)](https://www.acmicpc.net/problem/15650) | [정답 코드](../0x0C/solutions/15650.cpp), [별해 1](../0x0C/solutions/15650_1.cpp) |
+| 기본 문제✔ | 15651 | [N과 M (3)](https://www.acmicpc.net/problem/15651) | [정답 코드](../0x0C/solutions/15651.cpp) |
+| 기본 문제✔ | 15652 | [N과 M (4)](https://www.acmicpc.net/problem/15652) | [정답 코드](../0x0C/solutions/15652.cpp) |
+| 기본 문제✔ | 15654 | [N과 M (5)](https://www.acmicpc.net/problem/15654) | [정답 코드](../0x0C/solutions/15654.cpp) |
+| 기본 문제✔ | 15655 | [N과 M (6)](https://www.acmicpc.net/problem/15655) | [정답 코드](../0x0C/solutions/15655.cpp) |
+| 기본 문제✔ | 15656 | [N과 M (7)](https://www.acmicpc.net/problem/15656) | [정답 코드](../0x0C/solutions/15656.cpp) |
+| 기본 문제✔ | 15657 | [N과 M (8)](https://www.acmicpc.net/problem/15657) | [정답 코드](../0x0C/solutions/15657.cpp) |
+| 기본 문제✔ | 15663 | [N과 M (9)](https://www.acmicpc.net/problem/15663) | [정답 코드](../0x0C/solutions/15663.cpp) |
+| 기본 문제✔ | 15664 | [N과 M (10)](https://www.acmicpc.net/problem/15664) | [정답 코드](../0x0C/solutions/15664.cpp) |
+| 기본 문제✔ | 15665 | [N과 M (11)](https://www.acmicpc.net/problem/15665) | [정답 코드](../0x0C/solutions/15665.cpp) |
+| 기본 문제✔ | 15666 | [N과 M (12)](https://www.acmicpc.net/problem/15666) | [정답 코드](../0x0C/solutions/15666.cpp) |
+| 기본 문제✔ | 6603 | [로또](https://www.acmicpc.net/problem/6603) | [정답 코드](../0x0C/solutions/6603.cpp), [별해 1](../0x0C/solutions/6603_1.cpp) |
+| 기본 문제 | 1759 | [암호 만들기](https://www.acmicpc.net/problem/1759) | [정답 코드](../0x0C/solutions/1759.cpp), [별해 1](../0x0C/solutions/1759_1.cpp) |
+| 응용 문제✔ | 1941 | [소문난 칠공주](https://www.acmicpc.net/problem/1941) | [정답 코드](../0x0C/solutions/1941.cpp) |
+| 응용 문제✔ | 16987 | [계란으로 계란치기](https://www.acmicpc.net/problem/16987) | [정답 코드](../0x0C/solutions/16987.cpp) |
+| 응용 문제 | 18809 | [Gaaaaaaaaaarden](https://www.acmicpc.net/problem/18809) | [정답 코드](../0x0C/solutions/18809.cpp) |
+| 응용 문제 | 1799 | [비숍](https://www.acmicpc.net/problem/1799) | [정답 코드](../0x0C/solutions/1799.cpp) |

--- a/workbook/0x0D.md
+++ b/workbook/0x0D.md
@@ -1,8 +1,69 @@
 # 시뮬레이션
 
-![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0)
+![100%](https://progress-bar.xyz/42/?scale=61&title=progress&width=500&color=babaca&suffix=/61)
 
 [문제집 링크](https://www.acmicpc.net/workbook/view/7316)
 
 | 문제 분류 | 문제 | 문제 제목 | 정답 코드 |
 | :--: | :--: | :--: | :--: |
+| 연습 문제 | 15683 | [감시](https://www.acmicpc.net/problem/15683) | [정답 코드](../0x0D/solutions/15683.cpp) |
+| 연습 문제 | 18808 | [스티커 붙이기](https://www.acmicpc.net/problem/18808) | [정답 코드](../0x0D/solutions/18808.cpp) |
+| 연습 문제 | 12100 | [2048 (Easy)](https://www.acmicpc.net/problem/12100) | [정답 코드](../0x0D/solutions/12100.cpp) |
+| 연습 문제 | 15686 | [치킨 배달](https://www.acmicpc.net/problem/15686) | [정답 코드](../0x0D/solutions/15686.cpp) |
+| 기본 문제✔ | 11559 | [Puyo Puyo](https://www.acmicpc.net/problem/11559) | [정답 코드](../0x0D/solutions/11559.cpp) |
+| 기본 문제✔ | 14891 | [톱니바퀴](https://www.acmicpc.net/problem/14891) | [정답 코드](../0x0D/solutions/14891.cpp) |
+| 기본 문제✔ | 14499 | [주사위 굴리기](https://www.acmicpc.net/problem/14499) | [정답 코드](../0x0D/solutions/14499.cpp) |
+| 기본 문제✔ | 13335 | [트럭](https://www.acmicpc.net/problem/13335) | [정답 코드](../0x0D/solutions/13335.cpp), [별해 1](../0x0D/solutions/13335_1.cpp) |
+| 기본 문제✔ | 16985 | [Maaaaaaaaaze](https://www.acmicpc.net/problem/16985) | [정답 코드](../0x0D/solutions/16985.cpp) |
+| 기본 문제✔ | 14503 | [로봇 청소기](https://www.acmicpc.net/problem/14503) | [정답 코드](../0x0D/solutions/14503.cpp) |
+| 기본 문제✔ | 3190 | [뱀](https://www.acmicpc.net/problem/3190) | [정답 코드](../0x0D/solutions/3190.cpp) |
+| 기본 문제✔ | 14500 | [테트로미노](https://www.acmicpc.net/problem/14500) | [정답 코드](../0x0D/solutions/14500.cpp), [별해 1](../0x0D/solutions/14500_1.cpp), [별해 2](../0x0D/solutions/14500_2.cpp) |
+| 기본 문제✔ | 13460 | [구슬 탈출 2](https://www.acmicpc.net/problem/13460) | [정답 코드](../0x0D/solutions/13460.cpp) |
+| 기본 문제✔ | 14502 | [연구소](https://www.acmicpc.net/problem/14502) | [정답 코드](../0x0D/solutions/14502.cpp), [별해 1](../0x0D/solutions/14502_1.cpp), [별해 2](../0x0D/solutions/14502_2.cpp) |
+| 기본 문제✔ | 14888 | [연산자 끼워넣기](https://www.acmicpc.net/problem/14888) | [정답 코드](../0x0D/solutions/14888.cpp), [별해 1](../0x0D/solutions/14888_1.cpp) |
+| 기본 문제✔ | 14889 | [스타트와 링크](https://www.acmicpc.net/problem/14889) | [정답 코드](../0x0D/solutions/14889.cpp) |
+| 기본 문제✔ | 14890 | [경사로](https://www.acmicpc.net/problem/14890) | [정답 코드](../0x0D/solutions/14890.cpp) |
+| 기본 문제✔ | 15684 | [사다리 조작](https://www.acmicpc.net/problem/15684) | [정답 코드](../0x0D/solutions/15684.cpp) |
+| 기본 문제✔ | 15685 | [드래곤 커브](https://www.acmicpc.net/problem/15685) | [정답 코드](../0x0D/solutions/15685.cpp) |
+| 기본 문제 | 17281 | [⚾](https://www.acmicpc.net/problem/17281) | [정답 코드](../0x0D/solutions/17281.cpp), [별해 1](../0x0D/solutions/17281_1.cpp) |
+| 기본 문제 | 5373 | [큐빙](https://www.acmicpc.net/problem/5373) | [정답 코드](../0x0D/solutions/5373.cpp) |
+| 기본 문제 | 16234 | [인구 이동](https://www.acmicpc.net/problem/16234) | [정답 코드](../0x0D/solutions/16234.cpp) |
+| 기본 문제 | 16235 | [나무 재테크](https://www.acmicpc.net/problem/16235) | [정답 코드](../0x0D/solutions/16235.cpp) |
+| 기본 문제 | 16236 | [아기 상어](https://www.acmicpc.net/problem/16236) | [정답 코드](../0x0D/solutions/16236.cpp) |
+| 기본 문제 | 17140 | [이차원 배열과 연산](https://www.acmicpc.net/problem/17140) | [정답 코드](../0x0D/solutions/17140.cpp) |
+| 기본 문제 | 17141 | [연구소 2](https://www.acmicpc.net/problem/17141) | [정답 코드](../0x0D/solutions/17141.cpp) |
+| 기본 문제 | 17142 | [연구소 3](https://www.acmicpc.net/problem/17142) | [정답 코드](../0x0D/solutions/17142.cpp) |
+| 기본 문제 | 17143 | [낚시왕](https://www.acmicpc.net/problem/17143) | [정답 코드](../0x0D/solutions/17143.cpp) |
+| 기본 문제 | 17144 | [미세먼지 안녕!](https://www.acmicpc.net/problem/17144) | [정답 코드](../0x0D/solutions/17144.cpp) |
+| 기본 문제 | 4991 | [로봇 청소기](https://www.acmicpc.net/problem/4991) | - |
+| 기본 문제 | 16986 | [인싸들의 가위바위보](https://www.acmicpc.net/problem/16986) | [정답 코드](../0x0D/solutions/16986.cpp) |
+| 기본 문제 | 17779 | [게리맨더링 2](https://www.acmicpc.net/problem/17779) | - |
+| 기본 문제 | 17837 | [새로운 게임 2](https://www.acmicpc.net/problem/17837) | - |
+| 기본 문제 | 17822 | [원판 돌리기](https://www.acmicpc.net/problem/17822) | - |
+| 기본 문제 | 17825 | [주사위 윷놀이](https://www.acmicpc.net/problem/17825) | [정답 코드](../0x0D/solutions/17825.cpp) |
+| 기본 문제 | 19235 | [모노미노도미노](https://www.acmicpc.net/problem/19235) | [정답 코드](../0x0D/solutions/19235.cpp) |
+| 기본 문제 | 20061 | [모노미노도미노 2](https://www.acmicpc.net/problem/20061) | - |
+| 기본 문제 | 19236 | [청소년 상어](https://www.acmicpc.net/problem/19236) | [정답 코드](../0x0D/solutions/19236.cpp) |
+| 기본 문제 | 19237 | [어른 상어](https://www.acmicpc.net/problem/19237) | [정답 코드](../0x0D/solutions/19237.cpp) |
+| 기본 문제 | 19238 | [스타트 택시](https://www.acmicpc.net/problem/19238) | - |
+| 기본 문제 | 20055 | [컨베이어 벨트 위의 로봇](https://www.acmicpc.net/problem/20055) | [정답 코드](../0x0D/solutions/20055.cpp) |
+| 기본 문제 | 20056 | [마법사 상어와 파이어볼](https://www.acmicpc.net/problem/20056) | - |
+| 기본 문제 | 20057 | [마법사 상어와 토네이도](https://www.acmicpc.net/problem/20057) | - |
+| 기본 문제 | 20058 | [마법사 상어와 파이어스톰](https://www.acmicpc.net/problem/20058) | - |
+| 기본 문제 | 16637 | [괄호 추가하기](https://www.acmicpc.net/problem/16637) | - |
+| 기본 문제 | 17070 | [파이프 옮기기 1](https://www.acmicpc.net/problem/17070) | [정답 코드](../0x0D/solutions/17070.cpp), [별해 1](../0x0D/solutions/17070_1.cpp) |
+| 기본 문제 | 17135 | [캐슬 디펜스](https://www.acmicpc.net/problem/17135) | [정답 코드](../0x0D/solutions/17135.cpp) |
+| 기본 문제 | 17136 | [색종이 붙이기](https://www.acmicpc.net/problem/17136) | - |
+| 기본 문제 | 17406 | [배열 돌리기 4](https://www.acmicpc.net/problem/17406) | [정답 코드](../0x0D/solutions/17406.cpp) |
+| 기본 문제 | 17471 | [게리맨더링](https://www.acmicpc.net/problem/17471) | [정답 코드](../0x0D/solutions/17471.cpp) |
+| 기본 문제 | 17472 | [다리 만들기 2](https://www.acmicpc.net/problem/17472) | - |
+| 기본 문제 | 15898 | [피아의 아틀리에 ~신비한 대회의 연금술사~](https://www.acmicpc.net/problem/15898) | - |
+| 기본 문제 | 21608 | [상어 초등학교](https://www.acmicpc.net/problem/21608) | [정답 코드](../0x0D/solutions/21608.cpp) |
+| 기본 문제 | 21609 | [상어 중학교](https://www.acmicpc.net/problem/21609) | - |
+| 기본 문제 | 21610 | [마법사 상어와 비바라기](https://www.acmicpc.net/problem/21610) | - |
+| 기본 문제 | 21611 | [마법사 상어와 블리자드](https://www.acmicpc.net/problem/21611) | - |
+| 기본 문제 | 23288 | [주사위 굴리기 2](https://www.acmicpc.net/problem/23288) | [정답 코드](../0x0D/solutions/23288.cpp) |
+| 기본 문제 | 23289 | [온풍기 안녕!](https://www.acmicpc.net/problem/23289) | - |
+| 기본 문제 | 23290 | [마법사 상어와 복제](https://www.acmicpc.net/problem/23290) | [정답 코드](../0x0D/solutions/23290.cpp) |
+| 기본 문제 | 23291 | [어항 정리](https://www.acmicpc.net/problem/23291) | - |
+| 기본 문제 | 2478 | [자물쇠](https://www.acmicpc.net/problem/2478) | - |

--- a/workbook/0x0E.md
+++ b/workbook/0x0E.md
@@ -1,8 +1,16 @@
 # 정렬 I
 
-![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0)
+![100%](https://progress-bar.xyz/8/?scale=8&title=progress&width=500&color=babaca&suffix=/8)
 
 [문제집 링크](https://www.acmicpc.net/workbook/view/7317)
 
 | 문제 분류 | 문제 | 문제 제목 | 정답 코드 |
 | :--: | :--: | :--: | :--: |
+| 기본 문제 | 2750 | [수 정렬하기](https://www.acmicpc.net/problem/2750) | [정답 코드](../0x0E/solutions/2750.cpp) |
+| 기본 문제 | 2751 | [수 정렬하기 2](https://www.acmicpc.net/problem/2751) | [정답 코드](../0x0E/solutions/2751.cpp) |
+| 기본 문제 | 10989 | [수 정렬하기 3](https://www.acmicpc.net/problem/10989) | [정답 코드](../0x0E/solutions/10989.cpp) |
+| 기본 문제 | 11931 | [수 정렬하기 4](https://www.acmicpc.net/problem/11931) | [정답 코드](../0x0E/solutions/11931.cpp) |
+| 기본 문제 | 15688 | [수 정렬하기 5](https://www.acmicpc.net/problem/15688) | [정답 코드](../0x0E/solutions/15688.cpp) |
+| 기본 문제 | 10814 | [나이순 정렬](https://www.acmicpc.net/problem/10814) | [정답 코드](../0x0E/solutions/10814.cpp) |
+| 기본 문제 | 11650 | [좌표 정렬하기](https://www.acmicpc.net/problem/11650) | [정답 코드](../0x0E/solutions/11650.cpp) |
+| 기본 문제 | 11651 | [좌표 정렬하기 2](https://www.acmicpc.net/problem/11651) | [정답 코드](../0x0E/solutions/11651.cpp), [별해 1](../0x0E/solutions/11651_1.cpp) |

--- a/workbook/0x0F.md
+++ b/workbook/0x0F.md
@@ -1,8 +1,17 @@
 # 정렬 II
 
-![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0)
+![100%](https://progress-bar.xyz/9/?scale=9&title=progress&width=500&color=babaca&suffix=/9)
 
 [문제집 링크](https://www.acmicpc.net/workbook/view/7318)
 
 | 문제 분류 | 문제 | 문제 제목 | 정답 코드 |
 | :--: | :--: | :--: | :--: |
+| 연습 문제 | 1431 | [시리얼 번호](https://www.acmicpc.net/problem/1431) | [정답 코드](../0x0F/solutions/1431.cpp) |
+| 연습 문제 | 11652 | [카드](https://www.acmicpc.net/problem/11652) | [정답 코드](../0x0F/solutions/11652.cpp) |
+| 기본 문제✔ | 5648 | [역원소 정렬](https://www.acmicpc.net/problem/5648) | [정답 코드](../0x0F/solutions/5648.cpp) |
+| 기본 문제✔ | 1181 | [단어 정렬](https://www.acmicpc.net/problem/1181) | [정답 코드](../0x0F/solutions/1181.cpp) |
+| 기본 문제✔ | 2910 | [빈도 정렬](https://www.acmicpc.net/problem/2910) | [정답 코드](../0x0F/solutions/2910.cpp) |
+| 기본 문제 | 10814 | [나이순 정렬](https://www.acmicpc.net/problem/10814) | [정답 코드](../0x0F/solutions/10814.cpp) |
+| 기본 문제 | 11656 | [접미사 배열](https://www.acmicpc.net/problem/11656) | [정답 코드](../0x0F/solutions/11656.cpp) |
+| 기본 문제 | 10825 | [국영수](https://www.acmicpc.net/problem/10825) | [정답 코드](../0x0F/solutions/10825.cpp) |
+| 응용 문제✔ | 7795 | [먹을 것인가 먹힐 것인가](https://www.acmicpc.net/problem/7795) | [정답 코드](../0x0F/solutions/7795.cpp), [별해 1](../0x0F/solutions/7795_1.cpp) |

--- a/workbook/0x10.md
+++ b/workbook/0x10.md
@@ -1,8 +1,39 @@
 # 다이나믹 프로그래밍
 
-![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0)
+![100%](https://progress-bar.xyz/31/?scale=31&title=progress&width=500&color=babaca&suffix=/31)
 
 [문제집 링크](https://www.acmicpc.net/workbook/view/7319)
 
 | 문제 분류 | 문제 | 문제 제목 | 정답 코드 |
 | :--: | :--: | :--: | :--: |
+| 연습 문제 | 1463 | [1로 만들기](https://www.acmicpc.net/problem/1463) | [정답 코드](../0x10/solutions/1463.cpp) |
+| 연습 문제 | 9095 | [1, 2, 3 더하기](https://www.acmicpc.net/problem/9095) | [정답 코드](../0x10/solutions/9095.cpp) |
+| 연습 문제 | 2579 | [계단 오르기](https://www.acmicpc.net/problem/2579) | [정답 코드](../0x10/solutions/2579.cpp), [별해 1](../0x10/solutions/2579_1.cpp), [별해 2](../0x10/solutions/2579_2.cpp) |
+| 연습 문제 | 1149 | [RGB거리](https://www.acmicpc.net/problem/1149) | [정답 코드](../0x10/solutions/1149.cpp) |
+| 연습 문제 | 11726 | [2×n 타일링](https://www.acmicpc.net/problem/11726) | [정답 코드](../0x10/solutions/11726.cpp) |
+| 연습 문제 | 11659 | [구간 합 구하기 4](https://www.acmicpc.net/problem/11659) | [정답 코드](../0x10/solutions/11659.cpp) |
+| 연습 문제 | 12852 | [1로 만들기 2](https://www.acmicpc.net/problem/12852) | [정답 코드](../0x10/solutions/12852.cpp) |
+| 기본 문제✔ | 1003 | [피보나치 함수](https://www.acmicpc.net/problem/1003) | [정답 코드](../0x10/solutions/1003.cpp) |
+| 기본 문제✔ | 1932 | [정수 삼각형](https://www.acmicpc.net/problem/1932) | [정답 코드](../0x10/solutions/1932.cpp) |
+| 기본 문제✔ | 11727 | [2×n 타일링 2](https://www.acmicpc.net/problem/11727) | [정답 코드](../0x10/solutions/11727.cpp) |
+| 기본 문제✔ | 2193 | [이친수](https://www.acmicpc.net/problem/2193) | [정답 코드](../0x10/solutions/2193.cpp) |
+| 기본 문제✔ | 1912 | [연속합](https://www.acmicpc.net/problem/1912) | [정답 코드](../0x10/solutions/1912.cpp) |
+| 기본 문제✔ | 11055 | [가장 큰 증가하는 부분 수열](https://www.acmicpc.net/problem/11055) | [정답 코드](../0x10/solutions/11055.cpp) |
+| 기본 문제✔ | 11053 | [가장 긴 증가하는 부분 수열](https://www.acmicpc.net/problem/11053) | [정답 코드](../0x10/solutions/11053.cpp) |
+| 기본 문제✔ | 9461 | [파도반 수열](https://www.acmicpc.net/problem/9461) | [정답 코드](../0x10/solutions/9461.cpp) |
+| 기본 문제✔ | 14501 | [퇴사](https://www.acmicpc.net/problem/14501) | [정답 코드](../0x10/solutions/14501.cpp), [별해 1](../0x10/solutions/14501_1.cpp) |
+| 기본 문제✔ | 15486 | [퇴사 2](https://www.acmicpc.net/problem/15486) | [정답 코드](../0x10/solutions/15486.cpp) |
+| 기본 문제✔ | 10844 | [쉬운 계단 수](https://www.acmicpc.net/problem/10844) | [정답 코드](../0x10/solutions/10844.cpp) |
+| 기본 문제 | 2748 | [피보나치 수 2](https://www.acmicpc.net/problem/2748) | [정답 코드](../0x10/solutions/2748.cpp) |
+| 기본 문제 | 2240 | [자두나무](https://www.acmicpc.net/problem/2240) | [정답 코드](../0x10/solutions/2240.cpp), [별해 1](../0x10/solutions/2240_1.cpp) |
+| 기본 문제 | 14002 | [가장 긴 증가하는 부분 수열 4](https://www.acmicpc.net/problem/14002) | [정답 코드](../0x10/solutions/14002.cpp) |
+| 기본 문제 | 2156 | [포도주 시식](https://www.acmicpc.net/problem/2156) | [정답 코드](../0x10/solutions/2156.cpp), [별해 1](../0x10/solutions/2156_1.cpp) |
+| 기본 문제 | 15988 | [1, 2, 3 더하기 3](https://www.acmicpc.net/problem/15988) | [정답 코드](../0x10/solutions/15988.cpp) |
+| 기본 문제 | 2302 | [극장 좌석](https://www.acmicpc.net/problem/2302) | [정답 코드](../0x10/solutions/2302.cpp) |
+| 기본 문제 | 11052 | [카드 구매하기](https://www.acmicpc.net/problem/11052) | [정답 코드](../0x10/solutions/11052.cpp) |
+| 기본 문제 | 9465 | [스티커](https://www.acmicpc.net/problem/9465) | [정답 코드](../0x10/solutions/9465.cpp) |
+| 기본 문제 | 11057 | [오르막 수](https://www.acmicpc.net/problem/11057) | [정답 코드](../0x10/solutions/11057.cpp), [별해 1](../0x10/solutions/11057_1.cpp) |
+| 기본 문제 | 2293 | [동전 1](https://www.acmicpc.net/problem/2293) | [정답 코드](../0x10/solutions/2293.cpp) |
+| 기본 문제 | 1904 | [01타일](https://www.acmicpc.net/problem/1904) | [정답 코드](../0x10/solutions/1904.cpp) |
+| 기본 문제 | 1788 | [피보나치 수의 확장](https://www.acmicpc.net/problem/1788) | [정답 코드](../0x10/solutions/1788.cpp) |
+| 기본 문제 | 4883 | [삼각 그래프](https://www.acmicpc.net/problem/4883) | [정답 코드](../0x10/solutions/4883.cpp) |

--- a/workbook/0x11.md
+++ b/workbook/0x11.md
@@ -1,8 +1,25 @@
 # 그리디
 
-![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0)
+![100%](https://progress-bar.xyz/17/?scale=17&title=progress&width=500&color=babaca&suffix=/17)
 
 [문제집 링크](https://www.acmicpc.net/workbook/view/7320)
 
 | 문제 분류 | 문제 | 문제 제목 | 정답 코드 |
 | :--: | :--: | :--: | :--: |
+| 연습 문제 | 11047 | [동전 0](https://www.acmicpc.net/problem/11047) | [정답 코드](../0x11/solutions/11047.cpp) |
+| 연습 문제 | 1931 | [회의실 배정](https://www.acmicpc.net/problem/1931) | [정답 코드](../0x11/solutions/1931.cpp) |
+| 연습 문제 | 2217 | [로프](https://www.acmicpc.net/problem/2217) | [정답 코드](../0x11/solutions/2217.cpp) |
+| 연습 문제 | 1026 | [보물](https://www.acmicpc.net/problem/1026) | [정답 코드](../0x11/solutions/1026.cpp) |
+| 기본 문제✔ | 11399 | [ATM](https://www.acmicpc.net/problem/11399) | [정답 코드](../0x11/solutions/11399.cpp) |
+| 기본 문제✔ | 2457 | [공주님의 정원](https://www.acmicpc.net/problem/2457) | [정답 코드](../0x11/solutions/2457.cpp) |
+| 기본 문제✔ | 1541 | [잃어버린 괄호](https://www.acmicpc.net/problem/1541) | [정답 코드](../0x11/solutions/1541.cpp) |
+| 기본 문제✔ | 11501 | [주식](https://www.acmicpc.net/problem/11501) | [정답 코드](../0x11/solutions/11501.cpp) |
+| 기본 문제✔ | 1744 | [수 묶기](https://www.acmicpc.net/problem/1744) | [정답 코드](../0x11/solutions/1744.cpp) |
+| 기본 문제 | 2847 | [게임을 만든 동준이](https://www.acmicpc.net/problem/2847) | [정답 코드](../0x11/solutions/2847.cpp) |
+| 기본 문제 | 1439 | [뒤집기](https://www.acmicpc.net/problem/1439) | [정답 코드](../0x11/solutions/1439.cpp) |
+| 기본 문제 | 11000 | [강의실 배정](https://www.acmicpc.net/problem/11000) | [정답 코드](../0x11/solutions/11000.cpp), [별해 1](../0x11/solutions/11000_1.cpp) |
+| 기본 문제 | 15903 | [카드 합체 놀이](https://www.acmicpc.net/problem/15903) | [정답 코드](../0x11/solutions/15903.cpp), [별해 1](../0x11/solutions/15903_1.cpp) |
+| 응용 문제✔ | 2170 | [선 긋기](https://www.acmicpc.net/problem/2170) | [정답 코드](../0x11/solutions/2170.cpp), [별해 1](../0x11/solutions/2170_1.cpp) |
+| 응용 문제✔ | 1700 | [멀티탭 스케줄링](https://www.acmicpc.net/problem/1700) | [정답 코드](../0x11/solutions/1700.cpp) |
+| 응용 문제 | 8980 | [택배](https://www.acmicpc.net/problem/8980) | [정답 코드](../0x11/solutions/8980.cpp) |
+| 응용 문제 | 7570 | [줄 세우기](https://www.acmicpc.net/problem/7570) | [정답 코드](../0x11/solutions/7570.cpp) |

--- a/workbook/0x12.md
+++ b/workbook/0x12.md
@@ -1,8 +1,47 @@
 # 수학
 
-![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0)
+![100%](https://progress-bar.xyz/38/?scale=39&title=progress&width=500&color=babaca&suffix=/39)
 
 [문제집 링크](https://www.acmicpc.net/workbook/view/8174)
 
 | 문제 분류 | 문제 | 문제 제목 | 정답 코드 |
 | :--: | :--: | :--: | :--: |
+| 연습 문제 | 1978 | [소수 찾기](https://www.acmicpc.net/problem/1978) | [정답 코드](../0x12/solutions/1978.cpp) |
+| 연습 문제 | 1929 | [소수 구하기](https://www.acmicpc.net/problem/1929) | [정답 코드](../0x12/solutions/1929.cpp) |
+| 연습 문제 | 11653 | [소인수분해](https://www.acmicpc.net/problem/11653) | [정답 코드](../0x12/solutions/11653.cpp) |
+| 연습 문제 | 6064 | [카잉 달력](https://www.acmicpc.net/problem/6064) | [정답 코드](../0x12/solutions/6064.cpp) |
+| 연습 문제 | 11050 | [이항 계수 1](https://www.acmicpc.net/problem/11050) | [정답 코드](../0x12/solutions/11050.cpp) |
+| 연습 문제 | 11051 | [이항 계수 2](https://www.acmicpc.net/problem/11051) | [정답 코드](../0x12/solutions/11051.cpp) |
+| 기본 문제✔ | 15894 | [수학은 체육과목 입니다](https://www.acmicpc.net/problem/15894) | [정답 코드](../0x12/solutions/15894.cpp) |
+| 기본 문제✔ | 4796 | [캠핑](https://www.acmicpc.net/problem/4796) | [정답 코드](../0x12/solutions/4796.cpp) |
+| 기본 문제✔ | 2960 | [에라토스테네스의 체](https://www.acmicpc.net/problem/2960) | [정답 코드](../0x12/solutions/2960.cpp) |
+| 기본 문제✔ | 1193 | [분수찾기](https://www.acmicpc.net/problem/1193) | [정답 코드](../0x12/solutions/1193.cpp) |
+| 기본 문제✔ | 4948 | [베르트랑 공준](https://www.acmicpc.net/problem/4948) | [정답 코드](../0x12/solutions/4948.cpp) |
+| 기본 문제✔ | 1676 | [팩토리얼 0의 개수](https://www.acmicpc.net/problem/1676) | [정답 코드](../0x12/solutions/1676.cpp) |
+| 기본 문제✔ | 9613 | [GCD 합](https://www.acmicpc.net/problem/9613) | [정답 코드](../0x12/solutions/9613.cpp) |
+| 기본 문제 | 2292 | [벌집](https://www.acmicpc.net/problem/2292) | [정답 코드](../0x12/solutions/2292.cpp) |
+| 기본 문제 | 2869 | [달팽이는 올라가고 싶다](https://www.acmicpc.net/problem/2869) | [정답 코드](../0x12/solutions/2869.cpp) |
+| 기본 문제 | 10610 | [30](https://www.acmicpc.net/problem/10610) | [정답 코드](../0x12/solutions/10610.cpp) |
+| 기본 문제 | 6359 | [만취한 상범](https://www.acmicpc.net/problem/6359) | [정답 코드](../0x12/solutions/6359.cpp), [별해 1](../0x12/solutions/6359_1.cpp) |
+| 기본 문제 | 10250 | [ACM 호텔](https://www.acmicpc.net/problem/10250) | [정답 코드](../0x12/solutions/10250.cpp) |
+| 기본 문제 | 1456 | [거의 소수](https://www.acmicpc.net/problem/1456) | [정답 코드](../0x12/solutions/1456.cpp) |
+| 기본 문제 | 2839 | [설탕 배달](https://www.acmicpc.net/problem/2839) | [정답 코드](../0x12/solutions/2839.cpp) |
+| 기본 문제 | 17103 | [골드바흐 파티션](https://www.acmicpc.net/problem/17103) | [정답 코드](../0x12/solutions/17103.cpp) |
+| 기본 문제 | 2312 | [수 복원하기](https://www.acmicpc.net/problem/2312) | [정답 코드](../0x12/solutions/2312.cpp) |
+| 기본 문제 | 9020 | [골드바흐의 추측](https://www.acmicpc.net/problem/9020) | [정답 코드](../0x12/solutions/9020.cpp) |
+| 기본 문제 | 5347 | [LCM](https://www.acmicpc.net/problem/5347) | [정답 코드](../0x12/solutions/5347.cpp) |
+| 응용 문제✔ | 1476 | [날짜 계산](https://www.acmicpc.net/problem/1476) | [정답 코드](../0x12/solutions/1476.cpp) |
+| 응용 문제✔ | 1011 | [Fly me to the Alpha Centauri](https://www.acmicpc.net/problem/1011) | [정답 코드](../0x12/solutions/1011.cpp) |
+| 응용 문제✔ | 1038 | [감소하는 수](https://www.acmicpc.net/problem/1038) | [정답 코드](../0x12/solutions/1038.cpp), [별해 1](../0x12/solutions/1038_1.cpp) |
+| 응용 문제✔ | 1057 | [토너먼트](https://www.acmicpc.net/problem/1057) | [정답 코드](../0x12/solutions/1057.cpp), [별해 1](../0x12/solutions/1057_1.cpp) |
+| 응용 문제✔ | 2004 | [조합 0의 개수](https://www.acmicpc.net/problem/2004) | [정답 코드](../0x12/solutions/2004.cpp) |
+| 응용 문제✔ | 1292 | [쉽게 푸는 문제](https://www.acmicpc.net/problem/1292) | [정답 코드](../0x12/solutions/1292.cpp) |
+| 응용 문제✔ | 1790 | [수 이어 쓰기 2](https://www.acmicpc.net/problem/1790) | [정답 코드](../0x12/solutions/1790.cpp) |
+| 응용 문제✔ | 3036 | [링](https://www.acmicpc.net/problem/3036) | [정답 코드](../0x12/solutions/3036.cpp) |
+| 응용 문제 | 1735 | [분수 합](https://www.acmicpc.net/problem/1735) | [정답 코드](../0x12/solutions/1735.cpp) |
+| 응용 문제 | 3343 | [장미](https://www.acmicpc.net/problem/3343) | [정답 코드](../0x12/solutions/3343.cpp) |
+| 응용 문제 | 1963 | [소수 경로](https://www.acmicpc.net/problem/1963) | [정답 코드](../0x12/solutions/1963.cpp) |
+| 응용 문제 | 1747 | [소수&amp;팰린드롬](https://www.acmicpc.net/problem/1747) | [정답 코드](../0x12/solutions/1747.cpp), [별해 1](../0x12/solutions/1747_1.cpp) |
+| 응용 문제 | 1256 | [사전](https://www.acmicpc.net/problem/1256) | [정답 코드](../0x12/solutions/1256.cpp) |
+| 응용 문제 | 2089 | [-2진수](https://www.acmicpc.net/problem/2089) | [정답 코드](../0x12/solutions/2089.cpp) |
+| 응용 문제 | 1019 | [책 페이지](https://www.acmicpc.net/problem/1019) | - |

--- a/workbook/0x13.md
+++ b/workbook/0x13.md
@@ -1,8 +1,29 @@
 # 이분탐색
 
-![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0)
+![100%](https://progress-bar.xyz/20/?scale=21&title=progress&width=500&color=babaca&suffix=/21)
 
 [문제집 링크](https://www.acmicpc.net/workbook/view/8400)
 
 | 문제 분류 | 문제 | 문제 제목 | 정답 코드 |
 | :--: | :--: | :--: | :--: |
+| 연습 문제 | 1920 | [수 찾기](https://www.acmicpc.net/problem/1920) | [정답 코드](../0x13/solutions/1920.cpp), [별해 1](../0x13/solutions/1920_1.cpp) |
+| 연습 문제 | 10816 | [숫자 카드 2](https://www.acmicpc.net/problem/10816) | [정답 코드](../0x13/solutions/10816.cpp), [별해 1](../0x13/solutions/10816_1.cpp) |
+| 연습 문제 | 18870 | [좌표 압축](https://www.acmicpc.net/problem/18870) | [정답 코드](../0x13/solutions/18870.cpp), [별해 1](../0x13/solutions/18870_1.cpp) |
+| 연습 문제 | 2295 | [세 수의 합](https://www.acmicpc.net/problem/2295) | [정답 코드](../0x13/solutions/2295.cpp) |
+| 연습 문제 | 1654 | [랜선 자르기](https://www.acmicpc.net/problem/1654) | [정답 코드](../0x13/solutions/1654.cpp) |
+| 기본 문제✔ | 10815 | [숫자 카드](https://www.acmicpc.net/problem/10815) | [정답 코드](../0x13/solutions/10815.cpp) |
+| 기본 문제✔ | 1822 | [차집합](https://www.acmicpc.net/problem/1822) | [정답 코드](../0x13/solutions/1822.cpp) |
+| 기본 문제✔ | 16401 | [과자 나눠주기](https://www.acmicpc.net/problem/16401) | [정답 코드](../0x13/solutions/16401.cpp) |
+| 기본 문제✔ | 2805 | [나무 자르기](https://www.acmicpc.net/problem/2805) | [정답 코드](../0x13/solutions/2805.cpp) |
+| 기본 문제✔ | 18869 | [멀티버스 Ⅱ](https://www.acmicpc.net/problem/18869) | [정답 코드](../0x13/solutions/18869.cpp) |
+| 기본 문제✔ | 2467 | [용액](https://www.acmicpc.net/problem/2467) | [정답 코드](../0x13/solutions/2467.cpp), [별해 1](../0x13/solutions/2467_1.cpp) |
+| 기본 문제✔ | 3151 | [합이 0](https://www.acmicpc.net/problem/3151) | [정답 코드](../0x13/solutions/3151.cpp) |
+| 기본 문제 | 14921 | [용액 합성하기](https://www.acmicpc.net/problem/14921) | [정답 코드](../0x13/solutions/14921.cpp) |
+| 기본 문제 | 1253 | [좋다](https://www.acmicpc.net/problem/1253) | [정답 코드](../0x13/solutions/1253.cpp) |
+| 기본 문제 | 2143 | [두 배열의 합](https://www.acmicpc.net/problem/2143) | [정답 코드](../0x13/solutions/2143.cpp) |
+| 응용 문제✔ | 2473 | [세 용액](https://www.acmicpc.net/problem/2473) | [정답 코드](../0x13/solutions/2473.cpp) |
+| 응용 문제✔ | 2110 | [공유기 설치](https://www.acmicpc.net/problem/2110) | [정답 코드](../0x13/solutions/2110.cpp) |
+| 응용 문제✔ | 7453 | [합이 0인 네 정수](https://www.acmicpc.net/problem/7453) | [정답 코드](../0x13/solutions/7453.cpp) |
+| 응용 문제 | 12015 | [가장 긴 증가하는 부분 수열 2](https://www.acmicpc.net/problem/12015) | - |
+| 응용 문제 | 2512 | [예산](https://www.acmicpc.net/problem/2512) | [정답 코드](../0x13/solutions/2512.cpp) |
+| 응용 문제 | 1477 | [휴게소 세우기](https://www.acmicpc.net/problem/1477) | [정답 코드](../0x13/solutions/1477.cpp), [별해 1](../0x13/solutions/1477_1.cpp) |

--- a/workbook/0x14.md
+++ b/workbook/0x14.md
@@ -1,8 +1,19 @@
 # 투 포인터
 
-![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0)
+![100%](https://progress-bar.xyz/11/?scale=11&title=progress&width=500&color=babaca&suffix=/11)
 
 [문제집 링크](https://www.acmicpc.net/workbook/view/8709)
 
 | 문제 분류 | 문제 | 문제 제목 | 정답 코드 |
 | :--: | :--: | :--: | :--: |
+| 연습 문제 | 2230 | [수 고르기](https://www.acmicpc.net/problem/2230) | [정답 코드](../0x14/solutions/2230.cpp) |
+| 연습 문제 | 1806 | [부분합](https://www.acmicpc.net/problem/1806) | [정답 코드](../0x14/solutions/1806.cpp) |
+| 기본 문제✔ | 1644 | [소수의 연속합](https://www.acmicpc.net/problem/1644) | [정답 코드](../0x14/solutions/1644.cpp) |
+| 기본 문제✔ | 2003 | [수들의 합 2](https://www.acmicpc.net/problem/2003) | [정답 코드](../0x14/solutions/2003.cpp) |
+| 응용 문제✔ | 13144 | [List of Unique Numbers](https://www.acmicpc.net/problem/13144) | [정답 코드](../0x14/solutions/13144.cpp) |
+| 응용 문제✔ | 22862 | [가장 긴 짝수 연속한 부분 수열 (large)](https://www.acmicpc.net/problem/22862) | [정답 코드](../0x14/solutions/22862.cpp) |
+| 응용 문제✔ | 2531 | [회전 초밥](https://www.acmicpc.net/problem/2531) | [정답 코드](../0x14/solutions/2531.cpp) |
+| 응용 문제✔ | 20922 | [겹치는 건 싫어](https://www.acmicpc.net/problem/20922) | [정답 코드](../0x14/solutions/20922.cpp) |
+| 응용 문제 | 2461 | [대표 선수](https://www.acmicpc.net/problem/2461) | [정답 코드](../0x14/solutions/2461.cpp) |
+| 응용 문제 | 2283 | [구간 자르기](https://www.acmicpc.net/problem/2283) | [정답 코드](../0x14/solutions/2283.cpp) |
+| 응용 문제 | 20366 | [같이 눈사람 만들래?](https://www.acmicpc.net/problem/20366) | [정답 코드](../0x14/solutions/20366.cpp) |

--- a/workbook/0x15.md
+++ b/workbook/0x15.md
@@ -1,8 +1,17 @@
 # 해시
 
-![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0)
+![100%](https://progress-bar.xyz/9/?scale=9&title=progress&width=500&color=babaca&suffix=/9)
 
 [문제집 링크](https://www.acmicpc.net/workbook/view/9063)
 
 | 문제 분류 | 문제 | 문제 제목 | 정답 코드 |
 | :--: | :--: | :--: | :--: |
+| 연습 문제 | 7785 | [회사에 있는 사람](https://www.acmicpc.net/problem/7785) | [정답 코드](../0x15/solutions/7785.cpp) |
+| 연습 문제 | 1620 | [나는야 포켓몬 마스터 이다솜](https://www.acmicpc.net/problem/1620) | [정답 코드](../0x15/solutions/1620.cpp) |
+| 기본 문제✔ | 13414 | [수강신청](https://www.acmicpc.net/problem/13414) | [정답 코드](../0x15/solutions/13414.cpp) |
+| 기본 문제✔ | 17219 | [비밀번호 찾기](https://www.acmicpc.net/problem/17219) | [정답 코드](../0x15/solutions/17219.cpp) |
+| 기본 문제✔ | 9375 | [패션왕 신해빈](https://www.acmicpc.net/problem/9375) | [정답 코드](../0x15/solutions/9375.cpp) |
+| 기본 문제 | 16165 | [걸그룹 마스터 준석이](https://www.acmicpc.net/problem/16165) | [정답 코드](../0x15/solutions/16165.cpp) |
+| 기본 문제 | 11478 | [서로 다른 부분 문자열의 개수](https://www.acmicpc.net/problem/11478) | [정답 코드](../0x15/solutions/11478.cpp) |
+| 기본 문제 | 19583 | [싸이버개강총회](https://www.acmicpc.net/problem/19583) | [정답 코드](../0x15/solutions/19583.cpp) |
+| 응용 문제✔ | 20166 | [문자열 지옥에 빠진 호석](https://www.acmicpc.net/problem/20166) | [정답 코드](../0x15/solutions/20166.cpp) |

--- a/workbook/0x16.md
+++ b/workbook/0x16.md
@@ -1,8 +1,15 @@
 # 이진 검색 트리
 
-![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0)
+![100%](https://progress-bar.xyz/7/?scale=7&title=progress&width=500&color=babaca&suffix=/7)
 
 [문제집 링크](https://www.acmicpc.net/workbook/view/9346)
 
 | 문제 분류 | 문제 | 문제 제목 | 정답 코드 |
 | :--: | :--: | :--: | :--: |
+| 연습 문제 | 7662 | [이중 우선순위 큐](https://www.acmicpc.net/problem/7662) | [정답 코드](../0x16/solutions/7662.cpp) |
+| 연습 문제 | 1202 | [보석 도둑](https://www.acmicpc.net/problem/1202) | [정답 코드](../0x16/solutions/1202.cpp) |
+| 기본 문제✔ | 21939 | [문제 추천 시스템 Version 1](https://www.acmicpc.net/problem/21939) | [정답 코드](../0x16/solutions/21939.cpp) |
+| 기본 문제✔ | 23326 | [홍익 투어리스트](https://www.acmicpc.net/problem/23326) | [정답 코드](../0x16/solutions/23326.cpp) |
+| 응용 문제✔ | 21944 | [문제 추천 시스템 Version 2](https://www.acmicpc.net/problem/21944) | [정답 코드](../0x16/solutions/21944.cpp), [별해 1](../0x16/solutions/21944_1.cpp) |
+| 응용 문제✔ | 19700 | [수업](https://www.acmicpc.net/problem/19700) | [정답 코드](../0x16/solutions/19700.cpp) |
+| 응용 문제 | 1539 | [이진 검색 트리](https://www.acmicpc.net/problem/1539) | [정답 코드](../0x16/solutions/1539.cpp) |

--- a/workbook/0x17.md
+++ b/workbook/0x17.md
@@ -1,8 +1,16 @@
 # 우선순위 큐
 
-![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0)
+![100%](https://progress-bar.xyz/8/?scale=8&title=progress&width=500&color=babaca&suffix=/8)
 
 [문제집 링크](https://www.acmicpc.net/workbook/view/9502)
 
 | 문제 분류 | 문제 | 문제 제목 | 정답 코드 |
 | :--: | :--: | :--: | :--: |
+| 연습 문제 | 11286 | [절댓값 힙](https://www.acmicpc.net/problem/11286) | [정답 코드](../0x17/solutions/11286.cpp) |
+| 연습 문제 | 1715 | [카드 정렬하기](https://www.acmicpc.net/problem/1715) | [정답 코드](../0x17/solutions/1715.cpp) |
+| 기본 문제✔ | 1927 | [최소 힙](https://www.acmicpc.net/problem/1927) | [정답 코드](../0x17/solutions/1927.cpp) |
+| 기본 문제✔ | 2075 | [N번째 큰 수](https://www.acmicpc.net/problem/2075) | [정답 코드](../0x17/solutions/2075.cpp) |
+| 기본 문제 | 11279 | [최대 힙](https://www.acmicpc.net/problem/11279) | [정답 코드](../0x17/solutions/11279.cpp) |
+| 기본 문제 | 13975 | [파일 합치기 3](https://www.acmicpc.net/problem/13975) | [정답 코드](../0x17/solutions/13975.cpp) |
+| 응용 문제✔ | 1655 | [가운데를 말해요](https://www.acmicpc.net/problem/1655) | [정답 코드](../0x17/solutions/1655.cpp) |
+| 응용 문제✔ | 1781 | [컵라면](https://www.acmicpc.net/problem/1781) | [정답 코드](../0x17/solutions/1781.cpp) |

--- a/workbook/0x18.md
+++ b/workbook/0x18.md
@@ -1,8 +1,21 @@
 # 그래프
 
-![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0)
+![100%](https://progress-bar.xyz/13/?scale=13&title=progress&width=500&color=babaca&suffix=/13)
 
 [문제집 링크](https://www.acmicpc.net/workbook/view/9562)
 
 | 문제 분류 | 문제 | 문제 제목 | 정답 코드 |
 | :--: | :--: | :--: | :--: |
+| 연습 문제 | 11724 | [연결 요소의 개수](https://www.acmicpc.net/problem/11724) | [정답 코드](../0x18/solutions/11724.cpp) |
+| 연습 문제 | 1260 | [DFS와 BFS](https://www.acmicpc.net/problem/1260) | [정답 코드](../0x18/solutions/1260.cpp) |
+| 기본 문제✔ | 2606 | [바이러스](https://www.acmicpc.net/problem/2606) | [정답 코드](../0x18/solutions/2606.cpp) |
+| 기본 문제✔ | 5567 | [결혼식](https://www.acmicpc.net/problem/5567) | [정답 코드](../0x18/solutions/5567.cpp) |
+| 기본 문제✔ | 11403 | [경로 찾기](https://www.acmicpc.net/problem/11403) | [정답 코드](../0x18/solutions/11403.cpp) |
+| 기본 문제✔ | 2660 | [회장뽑기](https://www.acmicpc.net/problem/2660) | [정답 코드](../0x18/solutions/2660.cpp) |
+| 기본 문제 | 1389 | [케빈 베이컨의 6단계 법칙](https://www.acmicpc.net/problem/1389) | [정답 코드](../0x18/solutions/1389.cpp), [별해 1](../0x18/solutions/1389_1.cpp) |
+| 기본 문제 | 1325 | [효율적인 해킹](https://www.acmicpc.net/problem/1325) | [정답 코드](../0x18/solutions/1325.cpp) |
+| 기본 문제 | 6118 | [숨바꼭질](https://www.acmicpc.net/problem/6118) | [정답 코드](../0x18/solutions/6118.cpp) |
+| 응용 문제✔ | 1707 | [이분 그래프](https://www.acmicpc.net/problem/1707) | [정답 코드](../0x18/solutions/1707.cpp) |
+| 응용 문제✔ | 2617 | [구슬 찾기](https://www.acmicpc.net/problem/2617) | [정답 코드](../0x18/solutions/2617.cpp) |
+| 응용 문제✔ | 1043 | [거짓말](https://www.acmicpc.net/problem/1043) | [정답 코드](../0x18/solutions/1043.cpp) |
+| 응용 문제 | 5214 | [환승](https://www.acmicpc.net/problem/5214) | [정답 코드](../0x18/solutions/5214.cpp) |

--- a/workbook/0x19.md
+++ b/workbook/0x19.md
@@ -1,8 +1,21 @@
 # 트리
 
-![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0)
+![100%](https://progress-bar.xyz/13/?scale=13&title=progress&width=500&color=babaca&suffix=/13)
 
 [문제집 링크](https://www.acmicpc.net/workbook/view/9657)
 
 | 문제 분류 | 문제 | 문제 제목 | 정답 코드 |
 | :--: | :--: | :--: | :--: |
+| 연습 문제 | 11725 | [트리의 부모 찾기](https://www.acmicpc.net/problem/11725) | [정답 코드](../0x19/solutions/11725.cpp) |
+| 연습 문제 | 1991 | [트리 순회](https://www.acmicpc.net/problem/1991) | [정답 코드](../0x19/solutions/1991.cpp) |
+| 기본 문제✔ | 4803 | [트리](https://www.acmicpc.net/problem/4803) | [정답 코드](../0x19/solutions/4803.cpp) |
+| 기본 문제✔ | 15681 | [트리와 쿼리](https://www.acmicpc.net/problem/15681) | [정답 코드](../0x19/solutions/15681.cpp) |
+| 기본 문제✔ | 1240 | [노드사이의 거리](https://www.acmicpc.net/problem/1240) | [정답 코드](../0x19/solutions/1240.cpp) |
+| 기본 문제 | 22856 | [트리 순회](https://www.acmicpc.net/problem/22856) | [정답 코드](../0x19/solutions/22856.cpp) |
+| 기본 문제 | 1068 | [트리](https://www.acmicpc.net/problem/1068) | [정답 코드](../0x19/solutions/1068.cpp), [별해 1](../0x19/solutions/1068_1.cpp) |
+| 응용 문제✔ | 20955 | [민서의 응급 수술](https://www.acmicpc.net/problem/20955) | [정답 코드](../0x19/solutions/20955.cpp), [별해 1](../0x19/solutions/20955_1.cpp) |
+| 응용 문제✔ | 14267 | [회사 문화 1](https://www.acmicpc.net/problem/14267) | [정답 코드](../0x19/solutions/14267.cpp) |
+| 응용 문제✔ | 2250 | [트리의 높이와 너비](https://www.acmicpc.net/problem/2250) | [정답 코드](../0x19/solutions/2250.cpp) |
+| 응용 문제 | 2533 | [사회망 서비스(SNS)](https://www.acmicpc.net/problem/2533) | [정답 코드](../0x19/solutions/2533.cpp) |
+| 응용 문제 | 1967 | [트리의 지름](https://www.acmicpc.net/problem/1967) | [정답 코드](../0x19/solutions/1967.cpp), [별해 1](../0x19/solutions/1967_1.cpp) |
+| 응용 문제 | 1167 | [트리의 지름](https://www.acmicpc.net/problem/1167) | [정답 코드](../0x19/solutions/1167.cpp), [별해 1](../0x19/solutions/1167_1.cpp) |

--- a/workbook/0x1A.md
+++ b/workbook/0x1A.md
@@ -1,8 +1,15 @@
 # 위상 정렬
 
-![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0)
+![100%](https://progress-bar.xyz/7/?scale=7&title=progress&width=500&color=babaca&suffix=/7)
 
 [문제집 링크](https://www.acmicpc.net/workbook/view/9738)
 
 | 문제 분류 | 문제 | 문제 제목 | 정답 코드 |
 | :--: | :--: | :--: | :--: |
+| 연습 문제 | 2252 | [줄 세우기](https://www.acmicpc.net/problem/2252) | [정답 코드](../0x1A/solutions/2252.cpp) |
+| 기본 문제✔ | 2623 | [음악프로그램](https://www.acmicpc.net/problem/2623) | [정답 코드](../0x1A/solutions/2623.cpp) |
+| 기본 문제✔ | 21276 | [계보 복원가 호석](https://www.acmicpc.net/problem/21276) | [정답 코드](../0x1A/solutions/21276.cpp) |
+| 응용 문제✔ | 1766 | [문제집](https://www.acmicpc.net/problem/1766) | [정답 코드](../0x1A/solutions/1766.cpp) |
+| 응용 문제 | 2056 | [작업](https://www.acmicpc.net/problem/2056) | [정답 코드](../0x1A/solutions/2056.cpp) |
+| 응용 문제 | 1005 | [ACM Craft](https://www.acmicpc.net/problem/1005) | [정답 코드](../0x1A/solutions/1005.cpp), [별해 1](../0x1A/solutions/1005_1.cpp) |
+| 응용 문제 | 2637 | [장난감 조립](https://www.acmicpc.net/problem/2637) | [정답 코드](../0x1A/solutions/2637.cpp) |

--- a/workbook/0x1B.md
+++ b/workbook/0x1B.md
@@ -1,8 +1,17 @@
 # 최소 신장 트리
 
-![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0)
+![100%](https://progress-bar.xyz/9/?scale=9&title=progress&width=500&color=babaca&suffix=/9)
 
 [문제집 링크](https://www.acmicpc.net/workbook/view/9907)
 
 | 문제 분류 | 문제 | 문제 제목 | 정답 코드 |
 | :--: | :--: | :--: | :--: |
+| 연습 문제 | 1197 | [최소 스패닝 트리](https://www.acmicpc.net/problem/1197) | [정답 코드](../0x1B/solutions/1197.cpp), [별해 1](../0x1B/solutions/1197_1.cpp) |
+| 연습 문제 | 1368 | [물대기](https://www.acmicpc.net/problem/1368) | [정답 코드](../0x1B/solutions/1368.cpp), [별해 1](../0x1B/solutions/1368_1.cpp) |
+| 기본 문제✔ | 9372 | [상근이의 여행](https://www.acmicpc.net/problem/9372) | [정답 코드](../0x1B/solutions/9372.cpp) |
+| 기본 문제✔ | 16398 | [행성 연결](https://www.acmicpc.net/problem/16398) | [정답 코드](../0x1B/solutions/16398.cpp), [별해 1](../0x1B/solutions/16398_1.cpp) |
+| 기본 문제✔ | 1647 | [도시 분할 계획](https://www.acmicpc.net/problem/1647) | [정답 코드](../0x1B/solutions/1647.cpp) |
+| 응용 문제✔ | 13418 | [학교 탐방하기](https://www.acmicpc.net/problem/13418) | [정답 코드](../0x1B/solutions/13418.cpp) |
+| 응용 문제✔ | 1774 | [우주신과의 교감](https://www.acmicpc.net/problem/1774) | [정답 코드](../0x1B/solutions/1774.cpp) |
+| 응용 문제✔ | 10423 | [전기가 부족해](https://www.acmicpc.net/problem/10423) | [정답 코드](../0x1B/solutions/10423.cpp) |
+| 응용 문제 | 2887 | [행성 터널](https://www.acmicpc.net/problem/2887) | [정답 코드](../0x1B/solutions/2887.cpp) |

--- a/workbook/0x1C.md
+++ b/workbook/0x1C.md
@@ -1,8 +1,23 @@
 # 플로이드 알고리즘
 
-![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0)
+![100%](https://progress-bar.xyz/14/?scale=15&title=progress&width=500&color=babaca&suffix=/15)
 
 [문제집 링크](https://www.acmicpc.net/workbook/view/10318)
 
 | 문제 분류 | 문제 | 문제 제목 | 정답 코드 |
 | :--: | :--: | :--: | :--: |
+| 연습 문제 | 11404 | [플로이드](https://www.acmicpc.net/problem/11404) | [정답 코드](../0x1C/solutions/11404.cpp) |
+| 연습 문제 | 11780 | [플로이드 2](https://www.acmicpc.net/problem/11780) | [정답 코드](../0x1C/solutions/11780.cpp) |
+| 기본 문제✔ | 14938 | [서강그라운드](https://www.acmicpc.net/problem/14938) | [정답 코드](../0x1C/solutions/14938.cpp) |
+| 기본 문제✔ | 21940 | [가운데에서 만나기](https://www.acmicpc.net/problem/21940) | [정답 코드](../0x1C/solutions/21940.cpp) |
+| 기본 문제 | 17182 | [우주 탐사선](https://www.acmicpc.net/problem/17182) | [정답 코드](../0x1C/solutions/17182.cpp) |
+| 기본 문제 | 13168 | [내일로 여행](https://www.acmicpc.net/problem/13168) | [정답 코드](../0x1C/solutions/13168.cpp) |
+| 응용 문제✔ | 1956 | [운동](https://www.acmicpc.net/problem/1956) | [정답 코드](../0x1C/solutions/1956.cpp) |
+| 응용 문제✔ | 11562 | [백양로 브레이크](https://www.acmicpc.net/problem/11562) | [정답 코드](../0x1C/solutions/11562.cpp) |
+| 응용 문제✔ | 1507 | [궁금한 민호](https://www.acmicpc.net/problem/1507) | [정답 코드](../0x1C/solutions/1507.cpp) |
+| 응용 문제✔ | 1719 | [택배](https://www.acmicpc.net/problem/1719) | [정답 코드](../0x1C/solutions/1719.cpp) |
+| 응용 문제 | 13314 | [플로이드에 오타가?](https://www.acmicpc.net/problem/13314) | [정답 코드](../0x1C/solutions/13314.cpp) |
+| 응용 문제 | 23286 | [허들 넘기](https://www.acmicpc.net/problem/23286) | [정답 코드](../0x1C/solutions/23286.cpp) |
+| 응용 문제 | 13141 | [Ignition](https://www.acmicpc.net/problem/13141) | [정답 코드](../0x1C/solutions/13141.cpp) |
+| 응용 문제 | 23258 | [밤편지](https://www.acmicpc.net/problem/23258) | [정답 코드](../0x1C/solutions/23258.cpp) |
+| 응용 문제 | 1602 | [도망자 원숭이](https://www.acmicpc.net/problem/1602) | - |

--- a/workbook/0x1D.md
+++ b/workbook/0x1D.md
@@ -1,8 +1,22 @@
 # 다익스트라 알고리즘
 
-![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0)
+![100%](https://progress-bar.xyz/12/?scale=14&title=progress&width=500&color=babaca&suffix=/14)
 
 [문제집 링크](https://www.acmicpc.net/workbook/view/10433)
 
 | 문제 분류 | 문제 | 문제 제목 | 정답 코드 |
 | :--: | :--: | :--: | :--: |
+| 연습 문제 | 1753 | [최단경로](https://www.acmicpc.net/problem/1753) | [정답 코드](../0x1D/solutions/1753.cpp) |
+| 연습 문제 | 11779 | [최소비용 구하기 2](https://www.acmicpc.net/problem/11779) | [정답 코드](../0x1D/solutions/11779.cpp) |
+| 기본 문제✔ | 1238 | [파티](https://www.acmicpc.net/problem/1238) | [정답 코드](../0x1D/solutions/1238.cpp) |
+| 기본 문제✔ | 1504 | [특정한 최단 경로](https://www.acmicpc.net/problem/1504) | [정답 코드](../0x1D/solutions/1504.cpp) |
+| 기본 문제 | 1916 | [최소비용 구하기](https://www.acmicpc.net/problem/1916) | [정답 코드](../0x1D/solutions/1916.cpp) |
+| 응용 문제✔ | 1261 | [알고스팟](https://www.acmicpc.net/problem/1261) | [정답 코드](../0x1D/solutions/1261.cpp) |
+| 응용 문제✔ | 17835 | [면접보는 승범이네](https://www.acmicpc.net/problem/17835) | [정답 코드](../0x1D/solutions/17835.cpp) |
+| 응용 문제✔ | 20183 | [골목 대장 호석 - 효율성 2](https://www.acmicpc.net/problem/20183) | [정답 코드](../0x1D/solutions/20183.cpp) |
+| 응용 문제 | 24042 | [횡단보도](https://www.acmicpc.net/problem/24042) | [정답 코드](../0x1D/solutions/24042.cpp) |
+| 응용 문제 | 1162 | [도로포장](https://www.acmicpc.net/problem/1162) | [정답 코드](../0x1D/solutions/1162.cpp) |
+| 응용 문제 | 1854 | [K번째 최단경로 찾기](https://www.acmicpc.net/problem/1854) | - |
+| 응용 문제 | 5719 | [거의 최단 경로](https://www.acmicpc.net/problem/5719) | [정답 코드](../0x1D/solutions/5719.cpp) |
+| 응용 문제 | 13907 | [세금](https://www.acmicpc.net/problem/13907) | [정답 코드](../0x1D/solutions/13907.cpp) |
+| 응용 문제 | 22870 | [산책 (large)](https://www.acmicpc.net/problem/22870) | - |

--- a/workbook/0x1E.md
+++ b/workbook/0x1E.md
@@ -1,8 +1,16 @@
 # KMP
 
-![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0)
+![100%](https://progress-bar.xyz/8/?scale=8&title=progress&width=500&color=babaca&suffix=/8)
 
 [문제집 링크](https://www.acmicpc.net/workbook/view/12205)
 
 | 문제 분류 | 문제 | 문제 제목 | 정답 코드 |
 | :--: | :--: | :--: | :--: |
+| 연습 문제 | 16916 | [부분 문자열](https://www.acmicpc.net/problem/16916) | [정답 코드](../0x1E/solutions/16916.cpp) |
+| 기본 문제✔ | 16172 | [나는 친구가 적다 (Large)](https://www.acmicpc.net/problem/16172) | [정답 코드](../0x1E/solutions/16172.cpp) |
+| 기본 문제✔ | 1786 | [찾기](https://www.acmicpc.net/problem/1786) | [정답 코드](../0x1E/solutions/1786.cpp) |
+| 응용 문제✔ | 1893 | [시저 암호](https://www.acmicpc.net/problem/1893) | [정답 코드](../0x1E/solutions/1893.cpp) |
+| 응용 문제 | 1305 | [광고](https://www.acmicpc.net/problem/1305) | [정답 코드](../0x1E/solutions/1305.cpp) |
+| 응용 문제 | 4354 | [문자열 제곱](https://www.acmicpc.net/problem/4354) | [정답 코드](../0x1E/solutions/4354.cpp) |
+| 응용 문제 | 11585 | [속타는 저녁 메뉴](https://www.acmicpc.net/problem/11585) | [정답 코드](../0x1E/solutions/11585.cpp) |
+| 응용 문제 | 10266 | [시계 사진들](https://www.acmicpc.net/problem/10266) | [정답 코드](../0x1E/solutions/10266.cpp) |

--- a/workbook/0x1F.md
+++ b/workbook/0x1F.md
@@ -1,8 +1,18 @@
 # 트라이
 
-![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0)
+![100%](https://progress-bar.xyz/10/?scale=10&title=progress&width=500&color=babaca&suffix=/10)
 
 [문제집 링크](https://www.acmicpc.net/workbook/view/12649)
 
 | 문제 분류 | 문제 | 문제 제목 | 정답 코드 |
 | :--: | :--: | :--: | :--: |
+| 연습 문제 | 14425 | [문자열 집합](https://www.acmicpc.net/problem/14425) | [정답 코드](../0x1F/solutions/14425.cpp) |
+| 기본 문제✔ | 14426 | [접두사 찾기](https://www.acmicpc.net/problem/14426) | [정답 코드](../0x1F/solutions/14426.cpp) |
+| 기본 문제✔ | 5052 | [전화번호 목록](https://www.acmicpc.net/problem/5052) | [정답 코드](../0x1F/solutions/5052.cpp) |
+| 기본 문제 | 7432 | [디스크 트리](https://www.acmicpc.net/problem/7432) | [정답 코드](../0x1F/solutions/7432.cpp) |
+| 기본 문제 | 14725 | [개미굴](https://www.acmicpc.net/problem/14725) | [정답 코드](../0x1F/solutions/14725.cpp) |
+| 응용 문제✔ | 16934 | [게임 닉네임](https://www.acmicpc.net/problem/16934) | [정답 코드](../0x1F/solutions/16934.cpp) |
+| 응용 문제✔ | 9202 | [Boggle](https://www.acmicpc.net/problem/9202) | [정답 코드](../0x1F/solutions/9202.cpp) |
+| 응용 문제✔ | 16906 | [욱제어](https://www.acmicpc.net/problem/16906) | [정답 코드](../0x1F/solutions/16906.cpp) |
+| 응용 문제 | 5670 | [휴대폰 자판](https://www.acmicpc.net/problem/5670) | [정답 코드](../0x1F/solutions/5670.cpp) |
+| 응용 문제 | 5446 | [용량 부족](https://www.acmicpc.net/problem/5446) | [정답 코드](../0x1F/solutions/5446.cpp) |

--- a/workbook/Appendix A.md
+++ b/workbook/Appendix A.md
@@ -1,8 +1,24 @@
 # 문자열 기초
 
-![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0)
+![100%](https://progress-bar.xyz/13/?scale=16&title=progress&width=500&color=babaca&suffix=/16)
 
 [문제집 링크](https://www.acmicpc.net/workbook/view/14409)
 
 | 문제 분류 | 문제 | 문제 제목 | 정답 코드 |
 | :--: | :--: | :--: | :--: |
+| 연습 문제 | 1543 | [문서 검색](https://www.acmicpc.net/problem/1543) | [정답 코드](../Appendix%20A/solutions/1543.cpp) |
+| 연습 문제 | 2941 | [크로아티아 알파벳](https://www.acmicpc.net/problem/2941) | [정답 코드](../Appendix%20A/solutions/2941.cpp) |
+| 연습 문제 | 9996 | [한국이 그리울 땐 서버에 접속하지](https://www.acmicpc.net/problem/9996) | [정답 코드](../Appendix%20A/solutions/9996.cpp) |
+| 기본 문제✔ | 3613 | [Java vs C++](https://www.acmicpc.net/problem/3613) | [정답 코드](../Appendix%20A/solutions/3613.cpp) |
+| 기본 문제✔ | 2870 | [수학숙제](https://www.acmicpc.net/problem/2870) | [정답 코드](../Appendix%20A/solutions/2870.cpp) |
+| 기본 문제✔ | 1969 | [DNA](https://www.acmicpc.net/problem/1969) | [정답 코드](../Appendix%20A/solutions/1969.cpp) |
+| 기본 문제✔ | 2999 | [비밀 이메일](https://www.acmicpc.net/problem/2999) | [정답 코드](../Appendix%20A/solutions/2999.cpp) |
+| 기본 문제✔ | 9536 | [여우는 어떻게 울지?](https://www.acmicpc.net/problem/9536) | [정답 코드](../Appendix%20A/solutions/9536.cpp), [별해 1](../Appendix A/solutions/9536_1.cpp) |
+| 기본 문제✔ | 15312 | [이름 궁합](https://www.acmicpc.net/problem/15312) | [정답 코드](../Appendix%20A/solutions/15312.cpp) |
+| 기본 문제 | 3107 | [IPv6](https://www.acmicpc.net/problem/3107) | - |
+| 기본 문제 | 16719 | [ZOAC](https://www.acmicpc.net/problem/16719) | - |
+| 기본 문제 | 16113 | [시그널](https://www.acmicpc.net/problem/16113) | [정답 코드](../Appendix%20A/solutions/16113.cpp) |
+| 기본 문제 | 23304 | [아카라카](https://www.acmicpc.net/problem/23304) | [정답 코드](../Appendix%20A/solutions/23304.cpp) |
+| 기본 문제 | 6581 | [HTML](https://www.acmicpc.net/problem/6581) | [정답 코드](../Appendix%20A/solutions/6581.cpp) |
+| 기본 문제 | 17413 | [단어 뒤집기 2](https://www.acmicpc.net/problem/17413) | - |
+| 기본 문제 | 1213 | [팰린드롬 만들기](https://www.acmicpc.net/problem/1213) | [정답 코드](../Appendix%20A/solutions/1213.cpp) |

--- a/workbook/Appendix C.md
+++ b/workbook/Appendix C.md
@@ -1,8 +1,15 @@
 # 비트마스킹
 
-![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0)
+![100%](https://progress-bar.xyz/2/?scale=7&title=progress&width=500&color=babaca&suffix=/7)
 
 [문제집 링크](https://www.acmicpc.net/workbook/view/18875)
 
 | 문제 분류 | 문제 | 문제 제목 | 정답 코드 |
 | :--: | :--: | :--: | :--: |
+| 연습 문제 | 11723 | [집합](https://www.acmicpc.net/problem/11723) | [정답 코드](../Appendix%20C/solutions/11723.cpp) |
+| 연습 문제 | 1497 | [기타콘서트](https://www.acmicpc.net/problem/1497) | [정답 코드](../Appendix%20C/solutions/1497.cpp) |
+| 기본 문제✔ | 2961 | [도영이가 만든 맛있는 음식](https://www.acmicpc.net/problem/2961) | - |
+| 기본 문제✔ | 15787 | [기차가 어둠을 헤치고 은하수를](https://www.acmicpc.net/problem/15787) | - |
+| 기본 문제✔ | 24389 | [2의 보수](https://www.acmicpc.net/problem/24389) | - |
+| 응용 문제✔ | 2064 | [IP 주소](https://www.acmicpc.net/problem/2064) | - |
+| 응용 문제✔ | 17114 | [하이퍼 토마토](https://www.acmicpc.net/problem/17114) | - |

--- a/workbook/Appendix D.md
+++ b/workbook/Appendix D.md
@@ -1,8 +1,17 @@
 # Union-Find
 
-![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0)
+![100%](https://progress-bar.xyz/2/?scale=9&title=progress&width=500&color=babaca&suffix=/9)
 
 [문제집 링크](https://www.acmicpc.net/workbook/view/21218)
 
 | 문제 분류 | 문제 | 문제 제목 | 정답 코드 |
 | :--: | :--: | :--: | :--: |
+| 연습 문제 | 1717 | [집합의 표현](https://www.acmicpc.net/problem/1717) | [정답 코드](../Appendix%20D/solutions/1717.cpp) |
+| 연습 문제 | 7511 | [소셜 네트워킹 어플리케이션](https://www.acmicpc.net/problem/7511) | [정답 코드](../Appendix%20D/solutions/7511.cpp) |
+| 기본 문제✔ | 1976 | [여행 가자](https://www.acmicpc.net/problem/1976) | - |
+| 기본 문제✔ | 20040 | [사이클 게임](https://www.acmicpc.net/problem/20040) | - |
+| 응용 문제✔ | 18116 | [로봇 조립](https://www.acmicpc.net/problem/18116) | - |
+| 응용 문제✔ | 17619 | [개구리 점프](https://www.acmicpc.net/problem/17619) | - |
+| 응용 문제✔ | 14595 | [동방 프로젝트 (Large)](https://www.acmicpc.net/problem/14595) | - |
+| 응용 문제 | 10775 | [공항](https://www.acmicpc.net/problem/10775) | - |
+| 응용 문제 | 2162 | [선분 그룹](https://www.acmicpc.net/problem/2162) | - |

--- a/workbook/Appendix E.md
+++ b/workbook/Appendix E.md
@@ -1,8 +1,33 @@
 # 다이나믹 프로그래밍 심화
 
-![100%](https://progress-bar.xyz/0/?scale=0&title=progress&width=500&color=babaca&suffix=/0)
+![100%](https://progress-bar.xyz/17/?scale=25&title=progress&width=500&color=babaca&suffix=/25)
 
 [문제집 링크](https://www.acmicpc.net/workbook/view/23049)
 
 | 문제 분류 | 문제 | 문제 제목 | 정답 코드 |
 | :--: | :--: | :--: | :--: |
+| 연습 문제 | 9251 | [LCS](https://www.acmicpc.net/problem/9251) | [정답 코드](../Appendix%20E/solutions/9251.cpp) |
+| 연습 문제 | 9084 | [동전](https://www.acmicpc.net/problem/9084) | [정답 코드](../Appendix%20E/solutions/9084.cpp) |
+| 연습 문제 | 12865 | [평범한 배낭](https://www.acmicpc.net/problem/12865) | [정답 코드](../Appendix%20E/solutions/12865.cpp) |
+| 연습 문제 | 1915 | [가장 큰 정사각형](https://www.acmicpc.net/problem/1915) | [정답 코드](../Appendix%20E/solutions/1915.cpp) |
+| 연습 문제 | 1351 | [무한 수열](https://www.acmicpc.net/problem/1351) | [정답 코드](../Appendix%20E/solutions/1351.cpp) |
+| 연습 문제 | 1937 | [욕심쟁이 판다](https://www.acmicpc.net/problem/1937) | [정답 코드](../Appendix%20E/solutions/1937.cpp) |
+| 연습 문제 | 1949 | [우수 마을](https://www.acmicpc.net/problem/1949) | [정답 코드](../Appendix%20E/solutions/1949.cpp) |
+| 연습 문제 | 1005 | [ACM Craft](https://www.acmicpc.net/problem/1005) | [정답 코드](../Appendix%20E/solutions/1005.cpp) |
+| 기본 문제✔ | 10942 | [팰린드롬?](https://www.acmicpc.net/problem/10942) | [정답 코드](../Appendix%20E/solutions/10942.cpp) |
+| 기본 문제✔ | 1699 | [제곱수의 합](https://www.acmicpc.net/problem/1699) | [정답 코드](../Appendix%20E/solutions/1699.cpp) |
+| 기본 문제✔ | 9657 | [돌 게임 3](https://www.acmicpc.net/problem/9657) | [정답 코드](../Appendix%20E/solutions/9657.cpp) |
+| 기본 문제✔ | 11660 | [구간 합 구하기 5](https://www.acmicpc.net/problem/11660) | [정답 코드](../Appendix%20E/solutions/11660.cpp) |
+| 기본 문제✔ | 9665 | [GMO](https://www.acmicpc.net/problem/9665) | - |
+| 기본 문제✔ | 2011 | [암호코드](https://www.acmicpc.net/problem/2011) | [정답 코드](../Appendix%20E/solutions/2011.cpp) |
+| 기본 문제✔ | 12784 | [인하니카 공화국](https://www.acmicpc.net/problem/12784) | - |
+| 기본 문제✔ | 25515 | [트리 노드 합의 최댓값](https://www.acmicpc.net/problem/25515) | - |
+| 기본 문제✔ | 21276 | [계보 복원가 호석](https://www.acmicpc.net/problem/21276) | - |
+| 응용 문제✔ | 2294 | [동전 2](https://www.acmicpc.net/problem/2294) | [정답 코드](../Appendix%20E/solutions/2294.cpp) |
+| 응용 문제✔ | 2133 | [타일 채우기](https://www.acmicpc.net/problem/2133) | [정답 코드](../Appendix%20E/solutions/2133.cpp) |
+| 응용 문제✔ | 1520 | [내리막 길](https://www.acmicpc.net/problem/1520) | [정답 코드](../Appendix%20E/solutions/1520.cpp) |
+| 응용 문제✔ | 2482 | [색상환](https://www.acmicpc.net/problem/2482) | [정답 코드](../Appendix%20E/solutions/2482.cpp) |
+| 응용 문제✔ | 27501 | [RGB트리](https://www.acmicpc.net/problem/27501) | - |
+| 응용 문제✔ | 24232 | [망가진 나무](https://www.acmicpc.net/problem/24232) | - |
+| 응용 문제✔ | 3665 | [최종 순위](https://www.acmicpc.net/problem/3665) | - |
+| 응용 문제✔ | 2611 | [자동차경주](https://www.acmicpc.net/problem/2611) | - |


### PR DESCRIPTION
This reverts commit d3644b317e43196d969de4f8b035df659f9b7969.

## 수정

workbook 봇이 삭제한 문제집 링크 복원

## Before

<img width="584" height="247" alt="image" src="https://github.com/user-attachments/assets/63201486-70fd-41fd-aace-ea5d8e421aa0" />

## After

<img width="735" height="311" alt="image" src="https://github.com/user-attachments/assets/6f27e8c4-9631-46bb-8ac0-48b9049ac351" />
